### PR TITLE
Accept admin roles for operations platform

### DIFF
--- a/aws/operations-platform/README.md
+++ b/aws/operations-platform/README.md
@@ -45,6 +45,7 @@ CertManager, Cluster Autoscaler, and ExternalDNS.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_admin_roles"></a> [admin\_roles](#input\_admin\_roles) | Additional IAM roles which have admin cluster privileges | `list(string)` | `[]` | no |
 | <a name="input_argocd_github_repositories"></a> [argocd\_github\_repositories](#input\_argocd\_github\_repositories) | GitHub repositories to connect to ArgoCD | `list(string)` | `[]` | no |
 | <a name="input_argocd_policy"></a> [argocd\_policy](#input\_argocd\_policy) | Policy grants for ArgoCD RBAC | `string` | `""` | no |
 | <a name="input_argocd_values"></a> [argocd\_values](#input\_argocd\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
@@ -55,6 +56,7 @@ CertManager, Cluster Autoscaler, and ExternalDNS.
 | <a name="input_cluster_autoscaler_values"></a> [cluster\_autoscaler\_values](#input\_cluster\_autoscaler\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the EKS cluster | `string` | n/a | yes |
 | <a name="input_config_bucket"></a> [config\_bucket](#input\_config\_bucket) | Name of the S3 bucket for storing Flightdeck configuration | `string` | n/a | yes |
+| <a name="input_custom_roles"></a> [custom\_roles](#input\_custom\_roles) | Additional IAM roles which have custom cluster privileges | `map(string)` | `{}` | no |
 | <a name="input_dex_extra_secrets"></a> [dex\_extra\_secrets](#input\_dex\_extra\_secrets) | Extra values to append to the Dex secret | `map(string)` | `{}` | no |
 | <a name="input_dex_values"></a> [dex\_values](#input\_dex\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_domain_filters"></a> [domain\_filters](#input\_domain\_filters) | Domains on which External DNS should update entries | `list(string)` | `[]` | no |
@@ -62,6 +64,7 @@ CertManager, Cluster Autoscaler, and ExternalDNS.
 | <a name="input_host"></a> [host](#input\_host) | Base hostname for flightdeck UI | `string` | n/a | yes |
 | <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | Kubernetes namespace in which resources should be created | `string` | `"flightdeck"` | no |
 | <a name="input_kustomize_versions"></a> [kustomize\_versions](#input\_kustomize\_versions) | Versions of Kustomize to install | `list(string)` | <pre>[<br>  "3.10.0"<br>]</pre> | no |
+| <a name="input_node_roles"></a> [node\_roles](#input\_node\_roles) | Additional node roles which can join the cluster | `list(string)` | `[]` | no |
 | <a name="input_prometheus_operator_values"></a> [prometheus\_operator\_values](#input\_prometheus\_operator\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_workload_account_ids"></a> [workload\_account\_ids](#input\_workload\_account\_ids) | IDs of AWS accounts in which workloads will run | `list(string)` | `[]` | no |
 | <a name="input_workload_cluster_names"></a> [workload\_cluster\_names](#input\_workload\_cluster\_names) | Names of workload clusters to which ArgoCD will deploy | `list(string)` | `[]` | no |

--- a/aws/operations-platform/main.tf
+++ b/aws/operations-platform/main.tf
@@ -10,6 +10,7 @@ module "common_platform" {
   dex_values                 = var.dex_values
   host                       = var.host
   kustomize_versions         = var.kustomize_versions
+
   cert_manager_values = concat(
     module.workload_values.cert_manager_values,
     var.cert_manager_values
@@ -41,10 +42,13 @@ module "cluster_name" {
 module "workload_values" {
   source = "../workload-values"
 
+  admin_roles       = var.admin_roles
   aws_tags          = var.aws_tags
   cluster_full_name = module.cluster_name.full
+  custom_roles      = var.custom_roles
   domain_filters    = var.domain_filters
   k8s_namespace     = var.k8s_namespace
+  node_roles        = var.node_roles
 }
 
 module "argocd_service_account_role" {

--- a/aws/operations-platform/variables.tf
+++ b/aws/operations-platform/variables.tf
@@ -1,3 +1,9 @@
+variable "admin_roles" {
+  type        = list(string)
+  description = "Additional IAM roles which have admin cluster privileges"
+  default     = []
+}
+
 variable "argocd_github_repositories" {
   type        = list(string)
   description = "GitHub repositories to connect to ArgoCD"
@@ -38,6 +44,12 @@ variable "cluster_autoscaler_values" {
   description = "Overrides to pass to the Helm chart"
   type        = list(string)
   default     = []
+}
+
+variable "custom_roles" {
+  type        = map(string)
+  description = "Additional IAM roles which have custom cluster privileges"
+  default     = {}
 }
 
 variable "certificate_email" {
@@ -94,6 +106,12 @@ variable "kustomize_versions" {
   type        = list(string)
   description = "Versions of Kustomize to install"
   default     = ["3.10.0"]
+}
+
+variable "node_roles" {
+  type        = list(string)
+  description = "Additional node roles which can join the cluster"
+  default     = []
 }
 
 variable "prometheus_operator_values" {

--- a/aws/workload-platform/README.md
+++ b/aws/workload-platform/README.md
@@ -26,7 +26,6 @@ Cluster Autoscaler, and ExternalDNS.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_argocd_cluster_config"></a> [argocd\_cluster\_config](#module\_argocd\_cluster\_config) | ../argocd-cluster-config |  |
-| <a name="module_auth_config_map"></a> [auth\_config\_map](#module\_auth\_config\_map) | ../auth-config-map |  |
 | <a name="module_cluster_name"></a> [cluster\_name](#module\_cluster\_name) | ../cluster-name |  |
 | <a name="module_common_platform"></a> [common\_platform](#module\_common\_platform) | ../../common/workload-platform |  |
 | <a name="module_workload_values"></a> [workload\_values](#module\_workload\_values) | ../workload-values |  |
@@ -37,7 +36,6 @@ Cluster Autoscaler, and ExternalDNS.
 |------|------|
 | [aws_s3_bucket_object.cluster_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object) | resource |
 | [aws_s3_bucket_object.operations_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket_object) | data source |
-| [aws_ssm_parameter.node_role_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 
 ## Inputs
 

--- a/aws/workload-values/README.md
+++ b/aws/workload-values/README.md
@@ -16,6 +16,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_auth_config_map"></a> [auth\_config\_map](#module\_auth\_config\_map) | ../auth-config-map |  |
 | <a name="module_cluster_autoscaler_service_account_role"></a> [cluster\_autoscaler\_service\_account\_role](#module\_cluster\_autoscaler\_service\_account\_role) | ../cluster-autoscaler-service-account-role |  |
 | <a name="module_dns_service_account_role"></a> [dns\_service\_account\_role](#module\_dns\_service\_account\_role) | ../dns-service-account-role |  |
 
@@ -25,16 +26,20 @@
 |------|------|
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_route53_zone.managed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
+| [aws_ssm_parameter.node_role_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.oidc_issuer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_admin_roles"></a> [admin\_roles](#input\_admin\_roles) | IAM roles which will have admin privileges in this cluster | `list(string)` | n/a | yes |
 | <a name="input_aws_tags"></a> [aws\_tags](#input\_aws\_tags) | Tags to be applied to created AWS resources | `map(string)` | `{}` | no |
 | <a name="input_cluster_full_name"></a> [cluster\_full\_name](#input\_cluster\_full\_name) | Full name of the EKS cluster | `string` | n/a | yes |
+| <a name="input_custom_roles"></a> [custom\_roles](#input\_custom\_roles) | Additional IAM roles which have custom cluster privileges | `map(string)` | `{}` | no |
 | <a name="input_domain_filters"></a> [domain\_filters](#input\_domain\_filters) | Domains on which External DNS should update entries | `list(string)` | `[]` | no |
 | <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | Kubernetes namespace in which resources should be created | `string` | `"flightdeck"` | no |
+| <a name="input_node_roles"></a> [node\_roles](#input\_node\_roles) | Additional node roles which can join the cluster | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/aws/workload-values/main.tf
+++ b/aws/workload-values/main.tf
@@ -1,3 +1,12 @@
+module "auth_config_map" {
+  source = "../auth-config-map"
+
+  admin_roles       = var.admin_roles
+  cluster_full_name = var.cluster_full_name
+  custom_roles      = var.custom_roles
+  node_roles        = concat(local.node_roles, var.node_roles)
+}
+
 module "dns_service_account_role" {
   source = "../dns-service-account-role"
 
@@ -31,3 +40,14 @@ data "aws_ssm_parameter" "oidc_issuer" {
 }
 
 data "aws_region" "current" {}
+
+data "aws_ssm_parameter" "node_role_arn" {
+  name = join("/", concat(
+    [""],
+    ["flightdeck", var.cluster_full_name, "node_role_arn"]
+  ))
+}
+
+locals {
+  node_roles = [data.aws_ssm_parameter.node_role_arn.value]
+}

--- a/aws/workload-values/variables.tf
+++ b/aws/workload-values/variables.tf
@@ -1,3 +1,8 @@
+variable "admin_roles" {
+  type        = list(string)
+  description = "IAM roles which will have admin privileges in this cluster"
+}
+
 variable "aws_tags" {
   type        = map(string)
   description = "Tags to be applied to created AWS resources"
@@ -7,6 +12,12 @@ variable "aws_tags" {
 variable "cluster_full_name" {
   type        = string
   description = "Full name of the EKS cluster"
+}
+
+variable "custom_roles" {
+  type        = map(string)
+  description = "Additional IAM roles which have custom cluster privileges"
+  default     = {}
 }
 
 variable "domain_filters" {
@@ -19,4 +30,10 @@ variable "k8s_namespace" {
   type        = string
   default     = "flightdeck"
   description = "Kubernetes namespace in which resources should be created"
+}
+
+variable "node_roles" {
+  type        = list(string)
+  description = "Additional node roles which can join the cluster"
+  default     = []
 }


### PR DESCRIPTION
Manage the aws-auth ConfigMap in EKS so that we can specify roles that
should have admin privileges besides the user who created the cluster.
