### PR TITLE
Remove duplicate words from role account name

### DIFF
--- a/aws/service-account-role/main.tf
+++ b/aws/service-account-role/main.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "this" {
-  name                  = join("-", concat(var.namespace, [var.name]))
+  name                  = local.name
   assume_role_policy    = data.aws_iam_policy_document.assume_role.json
   force_detach_policies = true
   tags                  = var.tags
@@ -8,7 +8,7 @@ resource "aws_iam_role" "this" {
 resource "aws_iam_policy" "this" {
   for_each = toset(var.policy_json == null ? [] : ["static"])
 
-  name   = join("-", concat(var.namespace, [var.name]))
+  name   = local.name
   policy = var.policy_json
 }
 
@@ -60,3 +60,10 @@ data "aws_iam_policy_document" "assume_role" {
 
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
+
+locals {
+  name = join(
+    "-",
+    distinct(split("-", join("-", concat(var.namespace, [var.name]))))
+  )
+}

--- a/aws/service-account/main.tf
+++ b/aws/service-account/main.tf
@@ -9,7 +9,7 @@ resource "kubernetes_service_account" "this" {
 }
 
 module "role" {
-  source = "git@github.com:thoughtbot/flightdeck.git//aws/service-account-role?ref=f97a961"
+  source = "../service-account-role"
 
   name             = var.name
   namespace        = ["serviceaccount", var.cluster_name, var.namespace]


### PR DESCRIPTION
Role names must be within 64 characters. Removing duplicate words will help keep names within the limit.
