### PR TITLE
Fix cluster secret to use role policy attachment

### DIFF
--- a/aws/cluster-secret/README.md
+++ b/aws/cluster-secret/README.md
@@ -22,7 +22,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_iam_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [kubernetes_secret.this](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [aws_ssm_parameter.policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |

--- a/aws/cluster-secret/main.tf
+++ b/aws/cluster-secret/main.tf
@@ -7,10 +7,10 @@ resource "kubernetes_secret" "this" {
   data = jsondecode(data.aws_ssm_parameter.secret.value)
 }
 
-resource "aws_iam_policy_attachment" "this" {
+resource "aws_iam_role_policy_attachment" "this" {
   for_each = local.attachments
 
-  name       = each.value.name
+  role       = each.value.name
   policy_arn = each.value.policy_arn
 }
 


### PR DESCRIPTION
This was using `aws_iam_policy_attachment`, which controls all
attachments for a specific policy. The intended resource was
`aws_iam_role_policy_attachment`, which creates a 1-1 connection between
a role and a policy.
