### PR TITLE
Fix Terraform refusing to use non-sensitive value

### DIFF
--- a/aws/cluster-secret/main.tf
+++ b/aws/cluster-secret/main.tf
@@ -23,7 +23,7 @@ data "aws_ssm_parameter" "policies" {
 }
 
 locals {
-  policy_arns = jsondecode(data.aws_ssm_parameter.policies.value)
+  policy_arns = jsondecode(nonsensitive(data.aws_ssm_parameter.policies.value))
 
   attachment_values = flatten(
     [

--- a/aws/cluster-secret/providers.tf.json
+++ b/aws/cluster-secret/providers.tf.json
@@ -1,6 +1,6 @@
 {
   "terraform": {
-    "required_version": ">= 0.13.0",
+    "required_version": ">= 0.15.0",
     "required_providers": {
       "aws": {
         "version": "~> 3.0"


### PR DESCRIPTION
Terraform always marks the value of SSM parameters as sensitive[1], even
if they are declared as "String" and not "SecureString."

In Terraform 0.14, `for_each` was changed to fail when iterating over a
sensitive value, as that would record the sensitive value as part of the
stable identifier for a resource:

> Sensitive values, or values derived from sensitive values, cannot be
> used as for_each arguments. If used, the sensitive value could be
> exposed as a resource instance key.

Because these parameters contain ARNs for IAM policies and not secrets,
this changes the configuration to explicitly mark the value as
nonsensitive so that it can be used as part of the configuration.

[1]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter#value
