### PR TITLE
Attach policies outside service account role

### DIFF
--- a/aws/cluster-autoscaler-service-account-role/README.md
+++ b/aws/cluster-autoscaler-service-account-role/README.md
@@ -22,7 +22,9 @@
 
 | Name | Type |
 |------|------|
-| [aws_iam_policy_document.autoscaler_service_account_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 

--- a/aws/cluster-autoscaler-service-account-role/main.tf
+++ b/aws/cluster-autoscaler-service-account-role/main.tf
@@ -4,12 +4,21 @@ module "cluster_autoscaler_service_account_role" {
   name             = "cluster-autoscaler"
   namespace        = var.aws_namespace
   oidc_issuer      = var.oidc_issuer
-  policy_json      = data.aws_iam_policy_document.autoscaler_service_account_role.json
   service_accounts = ["${var.k8s_namespace}:cluster-autoscaler"]
   tags             = var.aws_tags
 }
 
-data "aws_iam_policy_document" "autoscaler_service_account_role" {
+resource "aws_iam_policy" "this" {
+  name   = module.cluster_autoscaler_service_account_role.name
+  policy = data.aws_iam_policy_document.this.json
+}
+
+resource "aws_iam_role_policy_attachment" "this" {
+  role       = module.cluster_autoscaler_service_account_role.name
+  policy_arn = aws_iam_policy.this.arn
+}
+
+data "aws_iam_policy_document" "this" {
   statement {
     actions = [
       "autoscaling:DescribeAutoScalingGroups",

--- a/aws/dns-service-account-role/README.md
+++ b/aws/dns-service-account-role/README.md
@@ -22,7 +22,9 @@
 
 | Name | Type |
 |------|------|
-| [aws_iam_policy_document.dns_service_account_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 

--- a/aws/dns-service-account-role/main.tf
+++ b/aws/dns-service-account-role/main.tf
@@ -4,7 +4,6 @@ module "dns_service_account_role" {
   name        = "dns"
   namespace   = var.aws_namespace
   oidc_issuer = var.oidc_issuer
-  policy_json = data.aws_iam_policy_document.dns_service_account_role.json
   tags        = var.aws_tags
 
   service_accounts = [
@@ -13,7 +12,17 @@ module "dns_service_account_role" {
   ]
 }
 
-data "aws_iam_policy_document" "dns_service_account_role" {
+resource "aws_iam_policy" "this" {
+  name   = module.dns_service_account_role.name
+  policy = data.aws_iam_policy_document.this.json
+}
+
+resource "aws_iam_role_policy_attachment" "this" {
+  role       = module.dns_service_account_role.name
+  policy_arn = aws_iam_policy.this.arn
+}
+
+data "aws_iam_policy_document" "this" {
   statement {
     actions = [
       "route53:GetChange"

--- a/aws/service-account-role/README.md
+++ b/aws/service-account-role/README.md
@@ -20,9 +20,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_iam_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
@@ -34,7 +32,6 @@ No modules.
 | <a name="input_name"></a> [name](#input\_name) | Name for the role | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Prefix to be applied to created resources | `list(string)` | `[]` | no |
 | <a name="input_oidc_issuer"></a> [oidc\_issuer](#input\_oidc\_issuer) | OIDC issuer of the Kubernetes cluster | `string` | n/a | yes |
-| <a name="input_policy_json"></a> [policy\_json](#input\_policy\_json) | IAM policy to create for this role | `string` | `null` | no |
 | <a name="input_service_accounts"></a> [service\_accounts](#input\_service\_accounts) | Namespace and name of service accounts allowed to use this role | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to created resources | `map(string)` | `{}` | no |
 
@@ -44,4 +41,5 @@ No modules.
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | The ARN of the created role |
 | <a name="output_instance"></a> [instance](#output\_instance) | The created role |
+| <a name="output_name"></a> [name](#output\_name) | The name of the created role |
 <!-- END_TF_DOCS -->

--- a/aws/service-account-role/main.tf
+++ b/aws/service-account-role/main.tf
@@ -5,20 +5,6 @@ resource "aws_iam_role" "this" {
   tags                  = var.tags
 }
 
-resource "aws_iam_policy" "this" {
-  for_each = toset(var.policy_json == null ? [] : ["static"])
-
-  name   = local.name
-  policy = var.policy_json
-}
-
-resource "aws_iam_role_policy_attachment" "this" {
-  for_each = aws_iam_policy.this
-
-  role       = aws_iam_role.this.name
-  policy_arn = each.value.arn
-}
-
 data "aws_iam_policy_document" "assume_role" {
   statement {
     actions = ["sts:AssumeRoleWithWebIdentity"]

--- a/aws/service-account-role/outputs.tf
+++ b/aws/service-account-role/outputs.tf
@@ -7,3 +7,8 @@ output "instance" {
   description = "The created role"
   value       = aws_iam_role.this
 }
+
+output "name" {
+  description = "The name of the created role"
+  value       = aws_iam_role.this.name
+}

--- a/aws/service-account-role/variables.tf
+++ b/aws/service-account-role/variables.tf
@@ -14,12 +14,6 @@ variable "oidc_issuer" {
   description = "OIDC issuer of the Kubernetes cluster"
 }
 
-variable "policy_json" {
-  type        = string
-  description = "IAM policy to create for this role"
-  default     = null
-}
-
 variable "service_accounts" {
   type        = list(string)
   description = "Namespace and name of service accounts allowed to use this role"


### PR DESCRIPTION
Currently the service-account-role module accepts an optional JSON
string. If present, it will be created as a policy and attached to the
created role. This provides a slight convenience with occasional blips
when applying terraform modules because the value is not known until
after apply, and Terraform gets confused by the for_each block that
makes the policy optional.

This moves the policies and attachments outside the module to eliminate
the dynamic portion of the module. It's slightly more verbose, but
clearer and eliminates the bugs during apply.
