### PR TITLE
Configure Alertmanager to use Pagerduty

### DIFF
--- a/aws/operations-platform/README.md
+++ b/aws/operations-platform/README.md
@@ -52,6 +52,7 @@ No resources.
 | <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | Kubernetes namespace in which resources should be created | `string` | `"flightdeck"` | no |
 | <a name="input_logs_retention_in_days"></a> [logs\_retention\_in\_days](#input\_logs\_retention\_in\_days) | Number of days for which logs should be retained | `number` | `30` | no |
 | <a name="input_node_roles"></a> [node\_roles](#input\_node\_roles) | Additional node roles which can join the cluster | `list(string)` | `[]` | no |
+| <a name="input_pagerduty_parameter"></a> [pagerduty\_parameter](#input\_pagerduty\_parameter) | SSM parameter containing the Pagerduty routing key | `string` | `null` | no |
 | <a name="input_prometheus_adapter_values"></a> [prometheus\_adapter\_values](#input\_prometheus\_adapter\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_prometheus_operator_values"></a> [prometheus\_operator\_values](#input\_prometheus\_operator\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 

--- a/aws/operations-platform/main.tf
+++ b/aws/operations-platform/main.tf
@@ -7,6 +7,7 @@ module "common_platform" {
   dex_values                = var.dex_values
   domain_names              = var.domain_names
   host                      = var.host
+  pagerduty_routing_key     = module.workload_values.pagerduty_routing_key
   prometheus_adapter_values = var.prometheus_adapter_values
 
   cert_manager_values = concat(
@@ -53,4 +54,5 @@ module "workload_values" {
   k8s_namespace          = var.k8s_namespace
   logs_retention_in_days = var.logs_retention_in_days
   node_roles             = var.node_roles
+  pagerduty_parameter    = var.pagerduty_parameter
 }

--- a/aws/operations-platform/variables.tf
+++ b/aws/operations-platform/variables.tf
@@ -103,6 +103,12 @@ variable "node_roles" {
   default     = []
 }
 
+variable "pagerduty_parameter" {
+  type        = string
+  description = "SSM parameter containing the Pagerduty routing key"
+  default     = null
+}
+
 variable "prometheus_adapter_values" {
   description = "Overrides to pass to the Helm chart"
   type        = list(string)

--- a/aws/workload-platform/README.md
+++ b/aws/workload-platform/README.md
@@ -46,9 +46,12 @@ No resources.
 | <a name="input_external_dns_values"></a> [external\_dns\_values](#input\_external\_dns\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_fluent_bit_values"></a> [fluent\_bit\_values](#input\_fluent\_bit\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_hosted_zones"></a> [hosted\_zones](#input\_hosted\_zones) | Domain names for hosted zones allowed in this cluster | `list(string)` | `[]` | no |
+| <a name="input_istio_discovery_values"></a> [istio\_discovery\_values](#input\_istio\_discovery\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
+| <a name="input_istio_ingress_values"></a> [istio\_ingress\_values](#input\_istio\_ingress\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | Kubernetes namespace in which resources should be created | `string` | `"flightdeck"` | no |
 | <a name="input_logs_retention_in_days"></a> [logs\_retention\_in\_days](#input\_logs\_retention\_in\_days) | Number of days for which logs should be retained | `number` | `30` | no |
 | <a name="input_node_roles"></a> [node\_roles](#input\_node\_roles) | Additional node roles which can join the cluster | `list(string)` | `[]` | no |
+| <a name="input_pagerduty_parameter"></a> [pagerduty\_parameter](#input\_pagerduty\_parameter) | SSM parameter containing the Pagerduty routing key | `string` | `null` | no |
 | <a name="input_prometheus_adapter_values"></a> [prometheus\_adapter\_values](#input\_prometheus\_adapter\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_prometheus_operator_values"></a> [prometheus\_operator\_values](#input\_prometheus\_operator\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 

--- a/aws/workload-platform/main.tf
+++ b/aws/workload-platform/main.tf
@@ -4,6 +4,9 @@ module "common_platform" {
   certificate_email         = var.certificate_email
   certificate_solvers       = module.workload_values.certificate_solvers
   domain_names              = var.domain_names
+  istio_discovery_values    = var.istio_discovery_values
+  istio_ingress_values      = var.istio_ingress_values
+  pagerduty_routing_key     = module.workload_values.pagerduty_routing_key
   prometheus_adapter_values = var.prometheus_adapter_values
 
   cert_manager_values = concat(
@@ -50,4 +53,5 @@ module "workload_values" {
   k8s_namespace          = var.k8s_namespace
   logs_retention_in_days = var.logs_retention_in_days
   node_roles             = var.node_roles
+  pagerduty_parameter    = var.pagerduty_parameter
 }

--- a/aws/workload-platform/variables.tf
+++ b/aws/workload-platform/variables.tf
@@ -62,6 +62,18 @@ variable "fluent_bit_values" {
   default     = []
 }
 
+variable "istio_discovery_values" {
+  description = "Overrides to pass to the Helm chart"
+  type        = list(string)
+  default     = []
+}
+
+variable "istio_ingress_values" {
+  description = "Overrides to pass to the Helm chart"
+  type        = list(string)
+  default     = []
+}
+
 variable "hosted_zones" {
   type        = list(string)
   description = "Domain names for hosted zones allowed in this cluster"
@@ -84,6 +96,12 @@ variable "node_roles" {
   type        = list(string)
   description = "Additional node roles which can join the cluster"
   default     = []
+}
+
+variable "pagerduty_parameter" {
+  type        = string
+  description = "SSM parameter containing the Pagerduty routing key"
+  default     = null
 }
 
 variable "prometheus_adapter_values" {

--- a/aws/workload-values/README.md
+++ b/aws/workload-values/README.md
@@ -29,6 +29,7 @@
 | [aws_route53_zone.managed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 | [aws_ssm_parameter.node_role_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.oidc_issuer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+| [aws_ssm_parameter.pagerduty_routing_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 
 ## Inputs
 
@@ -42,6 +43,7 @@
 | <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | Kubernetes namespace in which resources should be created | `string` | `"flightdeck"` | no |
 | <a name="input_logs_retention_in_days"></a> [logs\_retention\_in\_days](#input\_logs\_retention\_in\_days) | Number of days for which logs should be retained | `number` | `30` | no |
 | <a name="input_node_roles"></a> [node\_roles](#input\_node\_roles) | Additional node roles which can join the cluster | `list(string)` | `[]` | no |
+| <a name="input_pagerduty_parameter"></a> [pagerduty\_parameter](#input\_pagerduty\_parameter) | SSM parameter containing the Pagerduty routing key | `string` | `null` | no |
 
 ## Outputs
 
@@ -53,5 +55,6 @@
 | <a name="output_external_dns_values"></a> [external\_dns\_values](#output\_external\_dns\_values) | AWS-specific values for external-dns |
 | <a name="output_fluent_bit_values"></a> [fluent\_bit\_values](#output\_fluent\_bit\_values) | AWS-specific values for Fluent Bit |
 | <a name="output_oidc_issuer"></a> [oidc\_issuer](#output\_oidc\_issuer) | OIDC issuer configured for this cluster |
+| <a name="output_pagerduty_routing_key"></a> [pagerduty\_routing\_key](#output\_pagerduty\_routing\_key) | Routing key for delivering alerts to Pagerduty |
 | <a name="output_prometheus_operator_values"></a> [prometheus\_operator\_values](#output\_prometheus\_operator\_values) | AWS-specific values for Prometheus Operator |
 <!-- END_TF_DOCS -->

--- a/aws/workload-values/main.tf
+++ b/aws/workload-values/main.tf
@@ -59,6 +59,12 @@ data "aws_ssm_parameter" "node_role_arn" {
   ))
 }
 
+data "aws_ssm_parameter" "pagerduty_routing_key" {
+  count = var.pagerduty_parameter == null ? 0 : 1
+
+  name = var.pagerduty_parameter
+}
+
 locals {
   certificate_solvers = yamlencode([
     for hosted_zone in var.hosted_zones :

--- a/aws/workload-values/outputs.tf
+++ b/aws/workload-values/outputs.tf
@@ -114,6 +114,16 @@ output "oidc_issuer" {
   value       = data.aws_ssm_parameter.oidc_issuer.value
 }
 
+output "pagerduty_routing_key" {
+  description = "Routing key for delivering alerts to Pagerduty"
+
+  value = (
+    var.pagerduty_parameter == null ?
+    null :
+    join("", data.aws_ssm_parameter.pagerduty_routing_key.*.value)
+  )
+}
+
 output "prometheus_operator_values" {
   description = "AWS-specific values for Prometheus Operator"
   value = [
@@ -134,4 +144,3 @@ output "prometheus_operator_values" {
     })
   ]
 }
-

--- a/aws/workload-values/variables.tf
+++ b/aws/workload-values/variables.tf
@@ -43,3 +43,9 @@ variable "node_roles" {
   description = "Additional node roles which can join the cluster"
   default     = []
 }
+
+variable "pagerduty_parameter" {
+  type        = string
+  description = "SSM parameter containing the Pagerduty routing key"
+  default     = null
+}

--- a/common/operations-platform/README.md
+++ b/common/operations-platform/README.md
@@ -51,6 +51,7 @@ No resources.
 | <a name="input_istio_ingress_values"></a> [istio\_ingress\_values](#input\_istio\_ingress\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_istio_namespace"></a> [istio\_namespace](#input\_istio\_namespace) | Kubernetes namespace in which istio should be installed | `string` | `"istio-system"` | no |
 | <a name="input_istio_version"></a> [istio\_version](#input\_istio\_version) | Version of Istio to install | `string` | `"1.10.0"` | no |
+| <a name="input_pagerduty_routing_key"></a> [pagerduty\_routing\_key](#input\_pagerduty\_routing\_key) | Routing key for delivering Pagerduty alerts | `string` | `null` | no |
 | <a name="input_prometheus_adapter_values"></a> [prometheus\_adapter\_values](#input\_prometheus\_adapter\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_prometheus_adapter_version"></a> [prometheus\_adapter\_version](#input\_prometheus\_adapter\_version) | Version of external-dns to install | `string` | `"2.14.1"` | no |
 | <a name="input_prometheus_operator_values"></a> [prometheus\_operator\_values](#input\_prometheus\_operator\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |

--- a/common/operations-platform/main.tf
+++ b/common/operations-platform/main.tf
@@ -16,6 +16,7 @@ module "workload_platform" {
   istio_ingress_values        = var.istio_ingress_values
   istio_namespace             = var.istio_namespace
   istio_version               = var.istio_version
+  pagerduty_routing_key       = var.pagerduty_routing_key
   prometheus_adapter_values   = var.prometheus_adapter_values
   prometheus_adapter_version  = var.prometheus_adapter_version
   prometheus_operator_values  = var.prometheus_operator_values

--- a/common/operations-platform/variables.tf
+++ b/common/operations-platform/variables.tf
@@ -103,6 +103,12 @@ variable "istio_version" {
   default     = "1.10.0"
 }
 
+variable "pagerduty_routing_key" {
+  type        = string
+  description = "Routing key for delivering Pagerduty alerts"
+  default     = null
+}
+
 variable "prometheus_adapter_values" {
   description = "Overrides to pass to the Helm chart"
   type        = list(string)

--- a/common/prometheus-operator/README.md
+++ b/common/prometheus-operator/README.md
@@ -32,6 +32,7 @@ No modules.
 | <a name="input_chart_version"></a> [chart\_version](#input\_chart\_version) | Version of chart to install | `string` | n/a | yes |
 | <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | Kubernetes namespace in which resources will be written | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Name for the service account role | `string` | `"kube-prometheus-stack"` | no |
+| <a name="input_pagerduty_routing_key"></a> [pagerduty\_routing\_key](#input\_pagerduty\_routing\_key) | Routing key for delivering Pagerduty alerts | `string` | `null` | no |
 
 ## Outputs
 

--- a/common/prometheus-operator/variables.tf
+++ b/common/prometheus-operator/variables.tf
@@ -31,3 +31,9 @@ variable "name" {
   description = "Name for the service account role"
   default     = "kube-prometheus-stack"
 }
+
+variable "pagerduty_routing_key" {
+  type        = string
+  description = "Routing key for delivering Pagerduty alerts"
+  default     = null
+}

--- a/common/workload-platform/README.md
+++ b/common/workload-platform/README.md
@@ -58,9 +58,11 @@ Installs the components necessary for running workloads:
 | <a name="input_flightdeck_namespace"></a> [flightdeck\_namespace](#input\_flightdeck\_namespace) | Kubernetes namespace in which flightdeck should be installed | `string` | `"flightdeck"` | no |
 | <a name="input_fluent_bit_values"></a> [fluent\_bit\_values](#input\_fluent\_bit\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_fluent_bit_version"></a> [fluent\_bit\_version](#input\_fluent\_bit\_version) | Version of Fluent Bit to install | `string` | `"0.15.1"` | no |
+| <a name="input_istio_discovery_values"></a> [istio\_discovery\_values](#input\_istio\_discovery\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_istio_ingress_values"></a> [istio\_ingress\_values](#input\_istio\_ingress\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_istio_namespace"></a> [istio\_namespace](#input\_istio\_namespace) | Kubernetes namespace in which istio should be installed | `string` | `"istio-system"` | no |
 | <a name="input_istio_version"></a> [istio\_version](#input\_istio\_version) | Version of Istio to install | `string` | `"1.10.0"` | no |
+| <a name="input_pagerduty_routing_key"></a> [pagerduty\_routing\_key](#input\_pagerduty\_routing\_key) | Routing key for delivering Pagerduty alerts | `string` | `null` | no |
 | <a name="input_prometheus_adapter_values"></a> [prometheus\_adapter\_values](#input\_prometheus\_adapter\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_prometheus_adapter_version"></a> [prometheus\_adapter\_version](#input\_prometheus\_adapter\_version) | Version of external-dns to install | `string` | `"2.14.1"` | no |
 | <a name="input_prometheus_operator_values"></a> [prometheus\_operator\_values](#input\_prometheus\_operator\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |

--- a/common/workload-platform/main.tf
+++ b/common/workload-platform/main.tf
@@ -7,8 +7,9 @@ resource "kubernetes_namespace" "istio" {
 module "istio" {
   source = "../../common/istio"
 
-  istio_version = var.istio_version
-  k8s_namespace = kubernetes_namespace.istio.metadata[0].name
+  discovery_chart_values = var.istio_discovery_values
+  istio_version          = var.istio_version
+  k8s_namespace          = kubernetes_namespace.istio.metadata[0].name
 }
 
 module "ingress_config" {
@@ -79,9 +80,10 @@ module "istio_ingress" {
 module "prometheus_operator" {
   source = "../../common/prometheus-operator"
 
-  chart_values  = var.prometheus_operator_values
-  chart_version = var.prometheus_operator_version
-  k8s_namespace = kubernetes_namespace.flightdeck.metadata[0].name
+  chart_values          = var.prometheus_operator_values
+  chart_version         = var.prometheus_operator_version
+  k8s_namespace         = kubernetes_namespace.flightdeck.metadata[0].name
+  pagerduty_routing_key = var.pagerduty_routing_key
 
   depends_on = [module.cert_manager]
 }

--- a/common/workload-platform/variables.tf
+++ b/common/workload-platform/variables.tf
@@ -68,6 +68,12 @@ variable "fluent_bit_version" {
   default     = "0.15.1"
 }
 
+variable "istio_discovery_values" {
+  description = "Overrides to pass to the Helm chart"
+  type        = list(string)
+  default     = []
+}
+
 variable "istio_ingress_values" {
   description = "Overrides to pass to the Helm chart"
   type        = list(string)
@@ -84,6 +90,12 @@ variable "istio_version" {
   type        = string
   description = "Version of Istio to install"
   default     = "1.10.0"
+}
+
+variable "pagerduty_routing_key" {
+  type        = string
+  description = "Routing key for delivering Pagerduty alerts"
+  default     = null
 }
 
 variable "prometheus_adapter_values" {


### PR DESCRIPTION
When a Pagerduty routing key is available, configure Alertmanager to use Pagerduty using the given routing key.

Resolved #11.
