### PR TITLE
Allow separate providers for cluster and Route 53

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -41,7 +41,7 @@ rule "terraform_required_providers" {
 }
 
 rule "terraform_unused_required_providers" {
-  enabled = true
+  enabled = false
 }
 
 rule "terraform_standard_module_structure" {

--- a/aws/addon-secret/makefile
+++ b/aws/addon-secret/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/aws/auth-config-map/makefile
+++ b/aws/auth-config-map/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/aws/cloudwatch-logs/makefile
+++ b/aws/cloudwatch-logs/makefile
@@ -39,14 +39,28 @@ README.md: $(MODULEFILES)
 .PHONY: init
 init: .init
 
-.init: providers.tf.json
+.init: providers.tf.json .dependencies
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
+
+.dependencies: *.tf
+	@grep -ohE \
+		"\b(backend|provider|resource|module) ['\"][[:alpha:]][[:alnum:]]*|\bsource  *=.*" *.tf | \
+		sed "s/['\"]//" | sort | uniq | \
+		tee /tmp/initdeps | \
+		diff -q .dependencies - >/dev/null 2>&1 || \
+		mv /tmp/initdeps .dependencies
 
 .PHONY: clean
 clean:
-	rm -rf .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate

--- a/aws/cluster-autoscaler-service-account-role/makefile
+++ b/aws/cluster-autoscaler-service-account-role/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/aws/cluster-name/makefile
+++ b/aws/cluster-name/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/aws/cluster-secret/makefile
+++ b/aws/cluster-secret/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/aws/cluster/makefile
+++ b/aws/cluster/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/aws/codebuild-project/makefile
+++ b/aws/codebuild-project/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/aws/dns-service-account-role/makefile
+++ b/aws/dns-service-account-role/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/aws/ecr-build-script/makefile
+++ b/aws/ecr-build-script/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/aws/eks-cluster/makefile
+++ b/aws/eks-cluster/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/aws/eks-node-group/makefile
+++ b/aws/eks-node-group/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/aws/eks-node-role/makefile
+++ b/aws/eks-node-role/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/aws/ingress/README.md
+++ b/aws/ingress/README.md
@@ -10,6 +10,7 @@ cluster running in the configured network.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.45 |
 
 ## Providers
 
@@ -19,7 +20,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_alb"></a> [alb](#module\_alb) | git@github.com:thoughtbot/terraform-alb-ingress.git?ref=v0.1.0 |  |
+| <a name="module_alb"></a> [alb](#module\_alb) | git@github.com:thoughtbot/terraform-alb-ingress.git?ref=v0.2.0 |  |
 | <a name="module_network"></a> [network](#module\_network) | ../network-data |  |
 
 ## Resources

--- a/aws/ingress/main.tf
+++ b/aws/ingress/main.tf
@@ -1,5 +1,6 @@
 module "alb" {
-  source = "git@github.com:thoughtbot/terraform-alb-ingress.git?ref=v0.1.0"
+  providers = { aws.cluster = aws.cluster, aws.route53 = aws.route53 }
+  source    = "git@github.com:thoughtbot/terraform-alb-ingress.git?ref=v0.2.0"
 
   alarm_actions            = module.network.alarm_actions
   alarm_evaluation_minutes = var.alarm_evaluation_minutes

--- a/aws/ingress/makefile
+++ b/aws/ingress/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/aws/ingress/providers.tf.example
+++ b/aws/ingress/providers.tf.example
@@ -1,0 +1,9 @@
+provider "aws" {
+  alias  = "cluster"
+  region = "us-east-1"
+}
+
+provider "aws" {
+  alias  = "route53"
+  region = "us-east-1"
+}

--- a/aws/ingress/providers.tf.json
+++ b/aws/ingress/providers.tf.json
@@ -1,5 +1,15 @@
 {
   "terraform": {
-    "required_version": ">= 0.13.0"
+    "required_version": ">= 0.13.0",
+    "required_providers": {
+      "aws": {
+        "configuration_aliases": [
+          "aws.cluster",
+          "aws.route53"
+        ],
+        "source": "hashicorp/aws",
+        "version": "~> 3.45"
+      }
+    }
   }
 }

--- a/aws/k8s-oidc-provider/makefile
+++ b/aws/k8s-oidc-provider/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/aws/load-balancer-controller/makefile
+++ b/aws/load-balancer-controller/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/aws/nat-gateway/makefile
+++ b/aws/nat-gateway/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/aws/network-data/makefile
+++ b/aws/network-data/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/aws/network/makefile
+++ b/aws/network/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/aws/operations-platform/makefile
+++ b/aws/operations-platform/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/aws/private-subnets/makefile
+++ b/aws/private-subnets/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/aws/public-subnets/makefile
+++ b/aws/public-subnets/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/aws/s3-backend/makefile
+++ b/aws/s3-backend/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/aws/s3-bucket/makefile
+++ b/aws/s3-bucket/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/aws/service-account-role/makefile
+++ b/aws/service-account-role/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/aws/service-account/makefile
+++ b/aws/service-account/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/aws/vpc/makefile
+++ b/aws/vpc/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/aws/workload-platform/makefile
+++ b/aws/workload-platform/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/aws/workload-values/makefile
+++ b/aws/workload-values/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/common/cert-manager/makefile
+++ b/common/cert-manager/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/common/cluster-autoscaler/makefile
+++ b/common/cluster-autoscaler/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/common/dex/makefile
+++ b/common/dex/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/common/external-dns/makefile
+++ b/common/external-dns/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/common/fluent-bit/makefile
+++ b/common/fluent-bit/makefile
@@ -39,14 +39,28 @@ README.md: $(MODULEFILES)
 .PHONY: init
 init: .init
 
-.init: providers.tf.json
+.init: providers.tf.json .dependencies
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
+
+.dependencies: *.tf
+	@grep -ohE \
+		"\b(backend|provider|resource|module) ['\"][[:alpha:]][[:alnum:]]*|\bsource  *=.*" *.tf | \
+		sed "s/['\"]//" | sort | uniq | \
+		tee /tmp/initdeps | \
+		diff -q .dependencies - >/dev/null 2>&1 || \
+		mv /tmp/initdeps .dependencies
 
 .PHONY: clean
 clean:
-	rm -rf .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate

--- a/common/ingress-config/makefile
+++ b/common/ingress-config/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/common/istio-ingress/makefile
+++ b/common/istio-ingress/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/common/istio-namespace/makefile
+++ b/common/istio-namespace/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/common/istio/makefile
+++ b/common/istio/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/common/operations-platform/makefile
+++ b/common/operations-platform/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/common/prometheus-adapter/makefile
+++ b/common/prometheus-adapter/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/common/prometheus-operator/makefile
+++ b/common/prometheus-operator/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/common/ui/makefile
+++ b/common/ui/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/common/workload-platform/makefile
+++ b/common/workload-platform/makefile
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \

--- a/makefiles/terraform.mk
+++ b/makefiles/terraform.mk
@@ -43,9 +43,15 @@ init: .init
 	terraform init -backend=false
 	@touch .init
 
-.validate: .init $(MODULEFILES)
-	AWS_DEFAULT_REGION=us-east-1 terraform validate
-	@touch .validate
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
 
 .dependencies: *.tf
 	@grep -ohE \


### PR DESCRIPTION
This allows routing to be configured in one account and have the remaining resources provisioned in a different account. This is useful in a multi-account infrastructure with centralized DNS management.
