### PR TITLE
Accept cluster names and legacy target group names

### DIFF
--- a/aws/ingress/README.md
+++ b/aws/ingress/README.md
@@ -20,7 +20,8 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_alb"></a> [alb](#module\_alb) | git@github.com:thoughtbot/terraform-alb-ingress.git?ref=v0.2.0 |  |
+| <a name="module_alb"></a> [alb](#module\_alb) | git@github.com:thoughtbot/terraform-alb-ingress.git?ref=v0.3.0 |  |
+| <a name="module_cluster_name"></a> [cluster\_name](#module\_cluster\_name) | ../cluster-name |  |
 | <a name="module_network"></a> [network](#module\_network) | ../network-data |  |
 
 ## Resources
@@ -34,13 +35,15 @@ No resources.
 | <a name="input_alarm_evaluation_minutes"></a> [alarm\_evaluation\_minutes](#input\_alarm\_evaluation\_minutes) | Number of minutes of alarm state until triggering an alarm | `number` | `2` | no |
 | <a name="input_alarm_topic_name"></a> [alarm\_topic\_name](#input\_alarm\_topic\_name) | Name of the SNS topic to which alarms should be sent | `string` | `null` | no |
 | <a name="input_alternative_domain_names"></a> [alternative\_domain\_names](#input\_alternative\_domain\_names) | Alternative domain names for the ALB | `list(string)` | `[]` | no |
+| <a name="input_cluster_names"></a> [cluster\_names](#input\_cluster\_names) | List of clusters that this ingress stack will forward to | `list(string)` | n/a | yes |
 | <a name="input_create_aliases"></a> [create\_aliases](#input\_create\_aliases) | Set to false to disable creation of Route 53 aliases | `bool` | `true` | no |
 | <a name="input_failure_threshold"></a> [failure\_threshold](#input\_failure\_threshold) | Percentage of failed requests considered an anomaly | `number` | `5` | no |
 | <a name="input_hosted_zone_name"></a> [hosted\_zone\_name](#input\_hosted\_zone\_name) | Hosted zone for AWS Route53 | `string` | `null` | no |
 | <a name="input_issue_certificates"></a> [issue\_certificates](#input\_issue\_certificates) | Set to false to disable creation of ACM certificates | `bool` | `true` | no |
-| <a name="input_name"></a> [name](#input\_name) | Name of the AWS network in which ingress should be provided | `string` | `null` | no |
+| <a name="input_legacy_target_group_names"></a> [legacy\_target\_group\_names](#input\_legacy\_target\_group\_names) | Names of legacy target groups which should be included | `list(string)` | `[]` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of the AWS network in which ingress should be provided | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Prefix to apply to created resources | `list(string)` | `[]` | no |
-| <a name="input_network_tags"></a> [network\_tags](#input\_network\_tags) | Tags for finding the AWS VPC and subnets | `map(string)` | n/a | yes |
+| <a name="input_network_tags"></a> [network\_tags](#input\_network\_tags) | Tags for finding the AWS VPC and subnets | `map(string)` | `{}` | no |
 | <a name="input_primary_domain_name"></a> [primary\_domain\_name](#input\_primary\_domain\_name) | Primary domain name for the ALB | `string` | n/a | yes |
 | <a name="input_slow_response_threshold"></a> [slow\_response\_threshold](#input\_slow\_response\_threshold) | Response time considered extremely slow | `number` | `10` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to created resources | `map(string)` | `{}` | no |

--- a/aws/ingress/main.tf
+++ b/aws/ingress/main.tf
@@ -1,41 +1,51 @@
 module "alb" {
   providers = { aws.cluster = aws.cluster, aws.route53 = aws.route53 }
-  source    = "git@github.com:thoughtbot/terraform-alb-ingress.git?ref=v0.2.0"
+  source    = "git@github.com:thoughtbot/terraform-alb-ingress.git?ref=v0.3.0"
 
-  alarm_actions            = module.network.alarm_actions
-  alarm_evaluation_minutes = var.alarm_evaluation_minutes
-  alternative_domain_names = var.alternative_domain_names
-  create_aliases           = var.create_aliases
-  description              = "Flightdeck cluster load balancer"
-  failure_threshold        = var.failure_threshold
-  hosted_zone_name         = var.hosted_zone_name
-  issue_certificates       = var.issue_certificates
-  name                     = "${local.network_name}-ingress"
-  namespace                = var.namespace
-  primary_domain_name      = var.primary_domain_name
-  slow_response_threshold  = var.slow_response_threshold
-  subnets                  = module.network.public_subnets
-  tags                     = var.tags
-  target_groups            = local.target_groups
-  target_group_weights     = var.target_group_weights
-  validate_certificates    = var.validate_certificates
-  vpc                      = module.network.vpc
+  alarm_actions             = module.network.alarm_actions
+  alarm_evaluation_minutes  = var.alarm_evaluation_minutes
+  alternative_domain_names  = var.alternative_domain_names
+  create_aliases            = var.create_aliases
+  description               = "Flightdeck cluster load balancer"
+  failure_threshold         = var.failure_threshold
+  hosted_zone_name          = var.hosted_zone_name
+  issue_certificates        = var.issue_certificates
+  legacy_target_group_names = var.legacy_target_group_names
+  name                      = var.name
+  namespace                 = var.namespace
+  primary_domain_name       = var.primary_domain_name
+  slow_response_threshold   = var.slow_response_threshold
+  subnets                   = module.network.public_subnets
+  tags                      = var.tags
+  target_groups             = local.target_groups
+  target_group_weights      = var.target_group_weights
+  validate_certificates     = var.validate_certificates
+  vpc                       = module.network.vpc
 }
 
 module "network" {
   source = "../network-data"
 
   alarm_topic_name = var.alarm_topic_name
-  tags             = var.network_tags
+  tags             = merge(local.cluster_tags, var.network_tags)
+}
+
+module "cluster_name" {
+  for_each = toset(var.cluster_names)
+  source   = "../cluster-name"
+
+  name = each.value
 }
 
 locals {
-  network_name = coalesce(var.name, module.network.vpc.tags.Name)
+  cluster_tags = merge(
+    values(module.cluster_name).*.shared_tags...
+  )
 
   target_groups = zipmap(
-    module.network.cluster_names,
+    var.cluster_names,
     [
-      for cluster in module.network.cluster_names :
+      for cluster in var.cluster_names :
       {
         # This is the health check endpoint for istio-ingressgateway
         health_check_path = "/healthz/ready"

--- a/aws/ingress/variables.tf
+++ b/aws/ingress/variables.tf
@@ -16,6 +16,11 @@ variable "alternative_domain_names" {
   description = "Alternative domain names for the ALB"
 }
 
+variable "cluster_names" {
+  type        = list(string)
+  description = "List of clusters that this ingress stack will forward to"
+}
+
 variable "create_aliases" {
   description = "Set to false to disable creation of Route 53 aliases"
   type        = bool
@@ -40,10 +45,15 @@ variable "issue_certificates" {
   default     = true
 }
 
+variable "legacy_target_group_names" {
+  description = "Names of legacy target groups which should be included"
+  type        = list(string)
+  default     = []
+}
+
 variable "name" {
   description = "Name of the AWS network in which ingress should be provided"
   type        = string
-  default     = null
 }
 
 variable "namespace" {
@@ -55,6 +65,7 @@ variable "namespace" {
 variable "network_tags" {
   description = "Tags for finding the AWS VPC and subnets"
   type        = map(string)
+  default     = {}
 }
 
 variable "primary_domain_name" {


### PR DESCRIPTION
* Accept legacy target group names so that we can bring in existing target groups
* Accept explicit name and cluster names to avoid bug when trying to import an existing ALB

This avoids a recurring bug in Terraform where imports fail when `for_each` interacts with a data source.
