### PR TITLE
Skip looking up VPC when creating one

### DIFF
--- a/aws/network/outputs.tf
+++ b/aws/network/outputs.tf
@@ -5,5 +5,5 @@ output "cluster_names" {
 
 output "vpc_id" {
   description = "ID of the AWS VPC"
-  value       = data.aws_vpc.this.id
+  value       = local.vpc.id
 }


### PR DESCRIPTION
The current approach always looks up the VPC by CIDR block, even when creating one. This means that the Terraform plan threatens to delete and recreate all the subnets and other VPC resources, because it doesn't know until the plan is applied that it's using the same VPC.

The new approach skips looking up the VPC is it will already be available in Terraform state by creating or importing it.
