### PR TITLE
Fix dependency order errors from network-data

### DIFF
--- a/aws/cluster/main.tf
+++ b/aws/cluster/main.tf
@@ -21,8 +21,8 @@ module "eks_cluster" {
   k8s_version               = var.k8s_version
   log_retention_in_days     = var.log_retention_in_days
   name                      = module.cluster_name.full
-  private_subnets           = module.network.private_subnets
-  public_subnets            = module.network.public_subnets
+  private_subnet_ids        = module.network.private_subnet_ids
+  public_subnet_ids         = module.network.public_subnet_ids
   tags                      = var.tags
   vpc                       = module.network.vpc
 }
@@ -45,7 +45,7 @@ module "node_groups" {
   name           = each.key
   namespace      = [module.cluster_name.full]
   role           = module.node_role.instance
-  subnets        = module.network.private_subnets
+  subnet_ids     = module.network.private_subnet_ids
   tags           = var.tags
 
   depends_on = [module.node_role]

--- a/aws/eks-cluster/README.md
+++ b/aws/eks-cluster/README.md
@@ -38,8 +38,8 @@ No modules.
 | <a name="input_log_retention_in_days"></a> [log\_retention\_in\_days](#input\_log\_retention\_in\_days) | How many days until control plane logs are purged | `number` | `7` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name for this EKS cluster | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Prefix to be applied to created resources | `list(string)` | `[]` | no |
-| <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | Private subnets which should be used by this cluster | `map(object({ id = string }))` | n/a | yes |
-| <a name="input_public_subnets"></a> [public\_subnets](#input\_public\_subnets) | Public subnets which should be used by this cluster | `map(object({ id = string }))` | n/a | yes |
+| <a name="input_private_subnet_ids"></a> [private\_subnet\_ids](#input\_private\_subnet\_ids) | Private subnets which should be used by this cluster | `list(string)` | n/a | yes |
+| <a name="input_public_subnet_ids"></a> [public\_subnet\_ids](#input\_public\_subnet\_ids) | Public subnets which should be used by this cluster | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to created resources | `map(string)` | `{}` | no |
 | <a name="input_vpc"></a> [vpc](#input\_vpc) | VPC in which this cluster should run | `object({ id = string })` | n/a | yes |
 

--- a/aws/eks-cluster/main.tf
+++ b/aws/eks-cluster/main.tf
@@ -11,10 +11,7 @@ resource "aws_eks_cluster" "this" {
 
   vpc_config {
     security_group_ids = [aws_security_group.control_plane.id]
-    subnet_ids = concat(
-      values(var.private_subnets).*.id,
-      values(var.public_subnets).*.id
-    )
+    subnet_ids         = concat(var.private_subnet_ids, var.public_subnet_ids)
   }
 
   depends_on = [

--- a/aws/eks-cluster/variables.tf
+++ b/aws/eks-cluster/variables.tf
@@ -21,13 +21,13 @@ variable "namespace" {
   default     = []
 }
 
-variable "private_subnets" {
-  type        = map(object({ id = string }))
+variable "private_subnet_ids" {
+  type        = list(string)
   description = "Private subnets which should be used by this cluster"
 }
 
-variable "public_subnets" {
-  type        = map(object({ id = string }))
+variable "public_subnet_ids" {
+  type        = list(string)
   description = "Public subnets which should be used by this cluster"
 }
 

--- a/aws/eks-node-group/README.md
+++ b/aws/eks-node-group/README.md
@@ -21,6 +21,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_eks_node_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group) | resource |
+| [aws_subnet.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 
 ## Inputs
 
@@ -33,7 +34,7 @@ No modules.
 | <a name="input_name"></a> [name](#input\_name) | Name for this EKS node group | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Prefix to be applied to created resources | `list(string)` | `[]` | no |
 | <a name="input_role"></a> [role](#input\_role) | IAM role nodes in this group will assume | `object({ arn = string })` | n/a | yes |
-| <a name="input_subnets"></a> [subnets](#input\_subnets) | Subnets in which the node group should run | `map(object({ id = string }))` | n/a | yes |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnets in which the node group should run | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to created resources | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/aws/eks-node-group/main.tf
+++ b/aws/eks-node-group/main.tf
@@ -1,5 +1,5 @@
 resource "aws_eks_node_group" "this" {
-  for_each = var.subnets
+  for_each = local.subnets
 
   cluster_name    = var.cluster.name
   instance_types  = var.instance_types
@@ -22,7 +22,18 @@ resource "aws_eks_node_group" "this" {
   }
 }
 
+data "aws_subnet" "this" {
+  for_each = toset(var.subnet_ids)
+
+  id = each.value
+}
+
 locals {
   min_size_per_node_group = ceil(var.min_size / 2)
   max_size_per_node_group = ceil(var.max_size / 2)
+
+  subnets = zipmap(
+    values(data.aws_subnet.this).availability_zone,
+    values(data.aws_subnet.this)
+  )
 }

--- a/aws/eks-node-group/variables.tf
+++ b/aws/eks-node-group/variables.tf
@@ -35,8 +35,8 @@ variable "role" {
   description = "IAM role nodes in this group will assume"
 }
 
-variable "subnets" {
-  type        = map(object({ id = string }))
+variable "subnet_ids" {
+  type        = list(string)
   description = "Subnets in which the node group should run"
 }
 

--- a/aws/ingress/README.md
+++ b/aws/ingress/README.md
@@ -20,7 +20,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_alb"></a> [alb](#module\_alb) | git@github.com:thoughtbot/terraform-alb-ingress.git?ref=v0.3.0 |  |
+| <a name="module_alb"></a> [alb](#module\_alb) | git@github.com:thoughtbot/terraform-alb-ingress.git?ref=674bcf5 |  |
 | <a name="module_cluster_name"></a> [cluster\_name](#module\_cluster\_name) | ../cluster-name |  |
 | <a name="module_network"></a> [network](#module\_network) | ../network-data |  |
 

--- a/aws/ingress/main.tf
+++ b/aws/ingress/main.tf
@@ -1,6 +1,6 @@
 module "alb" {
   providers = { aws.cluster = aws.cluster, aws.route53 = aws.route53 }
-  source    = "git@github.com:thoughtbot/terraform-alb-ingress.git?ref=v0.3.0"
+  source    = "git@github.com:thoughtbot/terraform-alb-ingress.git?ref=674bcf5"
 
   alarm_actions             = module.network.alarm_actions
   alarm_evaluation_minutes  = var.alarm_evaluation_minutes
@@ -15,12 +15,12 @@ module "alb" {
   namespace                 = var.namespace
   primary_domain_name       = var.primary_domain_name
   slow_response_threshold   = var.slow_response_threshold
-  subnets                   = module.network.public_subnets
+  subnet_ids                = module.network.public_subnet_ids
   tags                      = var.tags
   target_groups             = local.target_groups
   target_group_weights      = var.target_group_weights
   validate_certificates     = var.validate_certificates
-  vpc                       = module.network.vpc
+  vpc_id                    = module.network.vpc.id
 
   depends_on = [module.network]
 }
@@ -35,6 +35,8 @@ module "network" {
 module "cluster_name" {
   for_each = toset(var.cluster_names)
   source   = "../cluster-name"
+
+  name = each.value
 }
 
 locals {

--- a/aws/network-data/README.md
+++ b/aws/network-data/README.md
@@ -21,8 +21,6 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_sns_topic.alarms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/sns_topic) | data source |
-| [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
-| [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 | [aws_subnet_ids.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
 | [aws_subnet_ids.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
 | [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
@@ -44,7 +42,7 @@ No modules.
 | <a name="output_alarm_actions"></a> [alarm\_actions](#output\_alarm\_actions) | AWS actions invoked on alarms in this network |
 | <a name="output_cidr_blocks"></a> [cidr\_blocks](#output\_cidr\_blocks) | CIDR blocks allowed in this network |
 | <a name="output_cluster_names"></a> [cluster\_names](#output\_cluster\_names) | List of clusters which run in this network |
-| <a name="output_private_subnets"></a> [private\_subnets](#output\_private\_subnets) | Private subnets for this network |
-| <a name="output_public_subnets"></a> [public\_subnets](#output\_public\_subnets) | Private subnets for this network |
+| <a name="output_private_subnet_ids"></a> [private\_subnet\_ids](#output\_private\_subnet\_ids) | Private subnets for this network |
+| <a name="output_public_subnet_ids"></a> [public\_subnet\_ids](#output\_public\_subnet\_ids) | Private subnets for this network |
 | <a name="output_vpc"></a> [vpc](#output\_vpc) | AWS VPC for this network |
 <!-- END_TF_DOCS -->

--- a/aws/network-data/main.tf
+++ b/aws/network-data/main.tf
@@ -7,21 +7,9 @@ data "aws_subnet_ids" "private" {
   vpc_id = data.aws_vpc.this.id
 }
 
-data "aws_subnet" "private" {
-  for_each = data.aws_subnet_ids.private.ids
-
-  id = each.value
-}
-
 data "aws_subnet_ids" "public" {
   tags   = merge(var.tags, var.public_tags)
   vpc_id = data.aws_vpc.this.id
-}
-
-data "aws_subnet" "public" {
-  for_each = data.aws_subnet_ids.public.ids
-
-  id = each.value
 }
 
 data "aws_sns_topic" "alarms" {
@@ -38,14 +26,4 @@ locals {
     split("/", tag)[2]
     if length(regexall("^kubernetes\\.io/cluster/", tag)) == 1
   ]
-
-  private_subnets = zipmap(
-    values(data.aws_subnet.private).*.availability_zone,
-    values(data.aws_subnet.private)
-  )
-
-  public_subnets = zipmap(
-    values(data.aws_subnet.public).*.availability_zone,
-    values(data.aws_subnet.public)
-  )
 }

--- a/aws/network-data/outputs.tf
+++ b/aws/network-data/outputs.tf
@@ -13,14 +13,14 @@ output "cidr_blocks" {
   value       = [data.aws_vpc.this.cidr_block]
 }
 
-output "private_subnets" {
+output "private_subnet_ids" {
   description = "Private subnets for this network"
-  value       = local.private_subnets
+  value       = data.aws_subnet_ids.public.ids
 }
 
-output "public_subnets" {
+output "public_subnet_ids" {
   description = "Private subnets for this network"
-  value       = local.public_subnets
+  value       = data.aws_subnet_ids.private.ids
 }
 
 output "vpc" {


### PR DESCRIPTION
- Use a ternary condition to short circuit
- Avoid using for_each on subnet IDs where possible
