### PR TITLE
Disable control plane logging by default

### DIFF
--- a/aws/cluster/README.md
+++ b/aws/cluster/README.md
@@ -51,7 +51,7 @@ An [OIDC provider](../k8s-oidc-provider) is configured to enable [IRSA].
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_alarm_topic_name"></a> [alarm\_topic\_name](#input\_alarm\_topic\_name) | Name of the SNS topic to which alarms should be sent | `string` | `null` | no |
-| <a name="input_enabled_cluster_log_types"></a> [enabled\_cluster\_log\_types](#input\_enabled\_cluster\_log\_types) | Which EKS control plane log types to enable | `list(string)` | <pre>[<br>  "api",<br>  "audit"<br>]</pre> | no |
+| <a name="input_enabled_cluster_log_types"></a> [enabled\_cluster\_log\_types](#input\_enabled\_cluster\_log\_types) | Which EKS control plane log types to enable | `list(string)` | `[]` | no |
 | <a name="input_k8s_version"></a> [k8s\_version](#input\_k8s\_version) | Kubernetes version to deploy | `string` | n/a | yes |
 | <a name="input_log_retention_in_days"></a> [log\_retention\_in\_days](#input\_log\_retention\_in\_days) | How many days until control plane logs are purged | `number` | `7` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name for this EKS cluster | `string` | n/a | yes |

--- a/aws/cluster/variables.tf
+++ b/aws/cluster/variables.tf
@@ -6,7 +6,7 @@ variable "alarm_topic_name" {
 
 variable "enabled_cluster_log_types" {
   type        = list(string)
-  default     = ["api", "audit"]
+  default     = []
   description = "Which EKS control plane log types to enable"
 }
 


### PR DESCRIPTION
While useful for debugging a cluster when setting up, control plane logs are not used regularly during cluster operation and are fairly verbose. This can result in large Cloudwatch logs spend for logs that nobody looks at.
