### PR TITLE
Disable annotations/labels in logs by default

### DIFF
--- a/aws/workload-platform/README.md
+++ b/aws/workload-platform/README.md
@@ -65,6 +65,8 @@ Cluster Autoscaler, and ExternalDNS.
 | <a name="input_domain_names"></a> [domain\_names](#input\_domain\_names) | Domains which are allowed in this cluster | `list(string)` | `[]` | no |
 | <a name="input_external_dns_enabled"></a> [external\_dns\_enabled](#input\_external\_dns\_enabled) | Set to true to enable External DNS | `bool` | `false` | no |
 | <a name="input_external_dns_values"></a> [external\_dns\_values](#input\_external\_dns\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
+| <a name="input_fluent_bit_enable_kubernetes_annotations"></a> [fluent\_bit\_enable\_kubernetes\_annotations](#input\_fluent\_bit\_enable\_kubernetes\_annotations) | Set to true to add Kubernetes annotations to log output | `bool` | `false` | no |
+| <a name="input_fluent_bit_enable_kubernetes_labels"></a> [fluent\_bit\_enable\_kubernetes\_labels](#input\_fluent\_bit\_enable\_kubernetes\_labels) | Set to true to add Kubernetes labels to log output | `bool` | `false` | no |
 | <a name="input_fluent_bit_values"></a> [fluent\_bit\_values](#input\_fluent\_bit\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_hosted_zones"></a> [hosted\_zones](#input\_hosted\_zones) | Hosted zones this cluster is allowed to update | `list(string)` | `[]` | no |
 | <a name="input_istio_discovery_values"></a> [istio\_discovery\_values](#input\_istio\_discovery\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |

--- a/aws/workload-platform/main.tf
+++ b/aws/workload-platform/main.tf
@@ -1,12 +1,14 @@
 module "common_platform" {
   source = "../../common/workload-platform"
 
-  certificate_issuer        = var.certificate_issuer
-  domain_names              = var.domain_names
-  external_dns_enabled      = var.external_dns_enabled
-  istio_discovery_values    = var.istio_discovery_values
-  pagerduty_routing_key     = local.pagerduty_routing_key
-  prometheus_adapter_values = var.prometheus_adapter_values
+  certificate_issuer                       = var.certificate_issuer
+  domain_names                             = var.domain_names
+  external_dns_enabled                     = var.external_dns_enabled
+  fluent_bit_enable_kubernetes_annotations = var.fluent_bit_enable_kubernetes_annotations
+  fluent_bit_enable_kubernetes_labels      = var.fluent_bit_enable_kubernetes_labels
+  istio_discovery_values                   = var.istio_discovery_values
+  pagerduty_routing_key                    = local.pagerduty_routing_key
+  prometheus_adapter_values                = var.prometheus_adapter_values
 
   cert_manager_values = concat(
     local.cert_manager_values,

--- a/aws/workload-platform/variables.tf
+++ b/aws/workload-platform/variables.tf
@@ -81,6 +81,18 @@ variable "external_dns_values" {
   default     = []
 }
 
+variable "fluent_bit_enable_kubernetes_annotations" {
+  description = "Set to true to add Kubernetes annotations to log output"
+  type        = bool
+  default     = false
+}
+
+variable "fluent_bit_enable_kubernetes_labels" {
+  description = "Set to true to add Kubernetes labels to log output"
+  type        = bool
+  default     = false
+}
+
 variable "fluent_bit_values" {
   description = "Overrides to pass to the Helm chart"
   type        = list(string)

--- a/common/fluent-bit/README.md
+++ b/common/fluent-bit/README.md
@@ -30,6 +30,8 @@ No modules.
 | <a name="input_chart_repository"></a> [chart\_repository](#input\_chart\_repository) | Helm repository containing the chart | `string` | `"https://fluent.github.io/helm-charts"` | no |
 | <a name="input_chart_values"></a> [chart\_values](#input\_chart\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_chart_version"></a> [chart\_version](#input\_chart\_version) | Version of chart to install | `string` | n/a | yes |
+| <a name="input_enable_kubernetes_annotations"></a> [enable\_kubernetes\_annotations](#input\_enable\_kubernetes\_annotations) | Set to true to add Kubernetes annotations to log output | `bool` | `false` | no |
+| <a name="input_enable_kubernetes_labels"></a> [enable\_kubernetes\_labels](#input\_enable\_kubernetes\_labels) | Set to true to add Kubernetes labels to log output | `bool` | `false` | no |
 | <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | Kubernetes namespace in which resources will be written | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Name for the Helm release | `string` | `"fluent-bit"` | no |
 

--- a/common/fluent-bit/filters.yaml
+++ b/common/fluent-bit/filters.yaml
@@ -1,0 +1,37 @@
+config:
+  ## https://docs.fluentbit.io/manual/pipeline/filters
+  filters: |
+    [FILTER]
+        Name kubernetes
+        Match kube.*
+        Merge_Log On
+        Keep_Log Off
+        K8S-Logging.Parser On
+        K8S-Logging.Exclude On
+
+        # Disable adding pod annotations and labels to logs
+        Annotations ${annotations}
+        Labels ${labels}
+
+    # Lift the nested "kubernetes" object with prefix "kube"
+    [FILTER]
+        Name nest
+        Match kube.*
+        Operation lift
+        Nested_under kubernetes
+        Add_prefix kube_
+
+    # Remove verbose Docker data
+    [FILTER]
+        Name modify
+        Match kube.*
+        Remove_regex ^kube_(container_hash|container_image|docker_id)$
+
+    # Re-nest the "kubernetes" object
+    [FILTER]
+        Name nest
+        Match kube.*
+        Operation nest
+        Wildcard kube_*
+        Nest_under kubernetes
+        Remove_prefix kube_

--- a/common/fluent-bit/main.tf
+++ b/common/fluent-bit/main.tf
@@ -11,6 +11,10 @@ locals {
   chart_values = [
     yamlencode({
       fullnameOverride = var.name
+    }),
+    templatefile("${path.module}/filters.yaml", {
+      annotations = var.enable_kubernetes_annotations ? "On" : "Off"
+      labels      = var.enable_kubernetes_labels ? "On" : "Off"
     })
   ]
 }

--- a/common/fluent-bit/variables.tf
+++ b/common/fluent-bit/variables.tf
@@ -21,6 +21,18 @@ variable "chart_repository" {
   default     = "https://fluent.github.io/helm-charts"
 }
 
+variable "enable_kubernetes_annotations" {
+  description = "Set to true to add Kubernetes annotations to log output"
+  type        = bool
+  default     = false
+}
+
+variable "enable_kubernetes_labels" {
+  description = "Set to true to add Kubernetes labels to log output"
+  type        = bool
+  default     = false
+}
+
 variable "k8s_namespace" {
   type        = string
   description = "Kubernetes namespace in which resources will be written"

--- a/common/workload-platform/README.md
+++ b/common/workload-platform/README.md
@@ -56,6 +56,8 @@ Installs the components necessary for running workloads:
 | <a name="input_external_dns_values"></a> [external\_dns\_values](#input\_external\_dns\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_external_dns_version"></a> [external\_dns\_version](#input\_external\_dns\_version) | Version of external-dns to install | `string` | `"5.0.0"` | no |
 | <a name="input_flightdeck_namespace"></a> [flightdeck\_namespace](#input\_flightdeck\_namespace) | Kubernetes namespace in which flightdeck should be installed | `string` | `"flightdeck"` | no |
+| <a name="input_fluent_bit_enable_kubernetes_annotations"></a> [fluent\_bit\_enable\_kubernetes\_annotations](#input\_fluent\_bit\_enable\_kubernetes\_annotations) | Set to true to add Kubernetes annotations to log output | `bool` | `false` | no |
+| <a name="input_fluent_bit_enable_kubernetes_labels"></a> [fluent\_bit\_enable\_kubernetes\_labels](#input\_fluent\_bit\_enable\_kubernetes\_labels) | Set to true to add Kubernetes labels to log output | `bool` | `false` | no |
 | <a name="input_fluent_bit_values"></a> [fluent\_bit\_values](#input\_fluent\_bit\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_fluent_bit_version"></a> [fluent\_bit\_version](#input\_fluent\_bit\_version) | Version of Fluent Bit to install | `string` | `"0.15.1"` | no |
 | <a name="input_istio_discovery_values"></a> [istio\_discovery\_values](#input\_istio\_discovery\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |

--- a/common/workload-platform/main.tf
+++ b/common/workload-platform/main.tf
@@ -39,7 +39,7 @@ module "cert_manager" {
 
   chart_values  = var.cert_manager_values
   chart_version = var.cert_manager_version
-  k8s_namespace = kubernetes_namespace.flightdeck.metadata[0].name
+  k8s_namespace = local.k8s_namespace
 }
 
 module "cluster_autoscaler" {
@@ -47,7 +47,7 @@ module "cluster_autoscaler" {
 
   chart_values  = var.cluster_autoscaler_values
   chart_version = var.cluster_autoscaler_version
-  k8s_namespace = kubernetes_namespace.flightdeck.metadata[0].name
+  k8s_namespace = local.k8s_namespace
 }
 
 module "external_dns" {
@@ -57,15 +57,17 @@ module "external_dns" {
 
   chart_values  = var.external_dns_values
   chart_version = var.external_dns_version
-  k8s_namespace = kubernetes_namespace.flightdeck.metadata[0].name
+  k8s_namespace = local.k8s_namespace
 }
 
 module "fluent_bit" {
   source = "../../common/fluent-bit"
 
-  chart_values  = var.fluent_bit_values
-  chart_version = var.fluent_bit_version
-  k8s_namespace = kubernetes_namespace.flightdeck.metadata[0].name
+  chart_values                  = var.fluent_bit_values
+  chart_version                 = var.fluent_bit_version
+  enable_kubernetes_annotations = var.fluent_bit_enable_kubernetes_annotations
+  enable_kubernetes_labels      = var.fluent_bit_enable_kubernetes_labels
+  k8s_namespace                 = local.k8s_namespace
 
   depends_on = [module.prometheus_operator]
 }
@@ -75,7 +77,7 @@ module "istio_ingress" {
 
   chart_values  = var.istio_ingress_values
   istio_version = var.istio_version
-  k8s_namespace = kubernetes_namespace.flightdeck.metadata[0].name
+  k8s_namespace = local.k8s_namespace
 }
 
 module "prometheus_operator" {
@@ -83,7 +85,7 @@ module "prometheus_operator" {
 
   chart_values          = var.prometheus_operator_values
   chart_version         = var.prometheus_operator_version
-  k8s_namespace         = kubernetes_namespace.flightdeck.metadata[0].name
+  k8s_namespace         = local.k8s_namespace
   pagerduty_routing_key = var.pagerduty_routing_key
 
   depends_on = [module.cert_manager]
@@ -94,7 +96,11 @@ module "prometheus_adapter" {
 
   chart_values  = var.prometheus_adapter_values
   chart_version = var.prometheus_adapter_version
-  k8s_namespace = kubernetes_namespace.flightdeck.metadata[0].name
+  k8s_namespace = local.k8s_namespace
 
   depends_on = [module.prometheus_operator]
+}
+
+locals {
+  k8s_namespace = kubernetes_namespace.flightdeck.metadata[0].name
 }

--- a/common/workload-platform/variables.tf
+++ b/common/workload-platform/variables.tf
@@ -58,6 +58,18 @@ variable "flightdeck_namespace" {
   description = "Kubernetes namespace in which flightdeck should be installed"
 }
 
+variable "fluent_bit_enable_kubernetes_annotations" {
+  description = "Set to true to add Kubernetes annotations to log output"
+  type        = bool
+  default     = false
+}
+
+variable "fluent_bit_enable_kubernetes_labels" {
+  description = "Set to true to add Kubernetes labels to log output"
+  type        = bool
+  default     = false
+}
+
 variable "fluent_bit_values" {
   description = "Overrides to pass to the Helm chart"
   type        = list(string)


### PR DESCRIPTION
Fluent Bit can add the pod annotations and labels to log output which makes it possible to find and aggregate logs by labels. While this could be useful, it creates extremely large log entries, which can be expensive in Cloudwatch.

This removes most of the Kubernetes metadata from the log output. It leaves namespace, container name, and pod name, which makes it possible to filter by a particular application or process.
