### PR TITLE
Ensure that fluent-bit can run on each node

### DIFF
--- a/common/fluent-bit/main.tf
+++ b/common/fluent-bit/main.tf
@@ -11,6 +11,9 @@ locals {
   chart_values = [
     yamlencode({
       fullnameOverride = var.name
+
+      # Ensure fluent-bit is able to run on each node
+      priorityClassName = "system-node-critical"
     }),
     templatefile("${path.module}/filters.yaml", {
       annotations = var.enable_kubernetes_annotations ? "On" : "Off"


### PR DESCRIPTION
Without a fluent-bit agent running, we're unable to send logs for each node. This marks fluent-bit pods as node critical so that Kubernetes will evict another pod if necessary to make room for fluent-bit.
