### PR TITLE
Expose metrics from Prometheus recording rules

### DIFF
--- a/common/prometheus-adapter/rules.yaml
+++ b/common/prometheus-adapter/rules.yaml
@@ -4,6 +4,21 @@ default: false
 
 # These metrics are for pod-aggregated metrics like requests per pod
 custom:
+
+# Expose any recorded metrics following the standard pod convention
+- seriesQuery: '{__name__=~"^pod:.*:.*$",pod!=""}'
+  resources:
+    overrides:
+      namespace:
+        resource: namespace
+      pod:
+        resource: pod
+  name:
+    matches: "^pod:([^:]*):([^:]*)$"
+    as: "${1}_${2}"
+  metricsQuery: (sum(irate(<<.Series>>{<<.LabelMatchers>>}[1m])) by (<<.GroupBy>>))
+
+# Expose total requests (ie istio_requests_total)
 - seriesQuery: '{__name__=~".*_requests_total$",pod!=""}'
   resources:
     overrides:
@@ -15,6 +30,8 @@ custom:
     matches: "^(.*)_total"
     as: "${1}_per_second"
   metricsQuery: (sum(irate(<<.Series>>{<<.LabelMatchers>>}[1m])) by (<<.GroupBy>>))
+
+# Expose jobs total (Sidekiq, DelayedJob)
 - seriesQuery: '{__name__=~".*_jobs_total$",pod!=""}'
   resources:
     overrides:
@@ -29,6 +46,19 @@ custom:
 
 # These metrics are for non-pod aggregated metrics like queue lengths
 external:
+
+# Expose any recorded metrics following the standard external convention
+- seriesQuery: '{__name__=~"^external:.*:.*$",namespace!=""}'
+  resources:
+    overrides:
+      namespace:
+        resource: namespace
+  name:
+    matches: "^external:([^:]*):([^:]*)$"
+    as: "${1}_${2}"
+  metricsQuery: (sum(irate(<<.Series>>{<<.LabelMatchers>>}[1m])) by (<<.GroupBy>>))
+
+# Queue backlogs (Sidekiq, DelayedJob)
 - seriesQuery: '{__name__=~".*_queue_backlog_total$",namespace!=""}'
   resources:
     overrides:
@@ -38,6 +68,8 @@ external:
     matches: "^(.*)_total"
     as: "${1}_total"
   metricsQuery: (max(<<.Series>>{<<.LabelMatchers>>}) by (namespace, queue))
+
+# Queue latency (Sidekiq)
 - seriesQuery: '{__name__=~".*_queue_latency_seconds$",namespace!=""}'
   resources:
     overrides:


### PR DESCRIPTION
Prometheus allows servers to be configure with recording rules[1] which will precompute aggregates for frequently-accessed metrics. Prometheus allows documents some best practices[2] for standard recording rule names.

This adds rules for Prometheus adapter to expose metrics following the recommended names. This allows an application to declare recording rules using PrometheusRule CRD[3] from the Prometheus Operator and then consume that metrics from the Kubernetes metrics API[4], such as in a horizontal pod autoscaler.

[1]: https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/
[2]: https://prometheus.io/docs/practices/rules/
[3]: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#prometheusrule
[4]: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/instrumentation/custom-metrics-api.md
