### PR TITLE
Add metrics for services

### DIFF
--- a/common/prometheus-adapter/rules.yaml
+++ b/common/prometheus-adapter/rules.yaml
@@ -16,7 +16,20 @@ custom:
   name:
     matches: "^pod:([^:]*):([^:]*)$"
     as: "${1}_${2}"
-  metricsQuery: (sum(irate(<<.Series>>{<<.LabelMatchers>>}[1m])) by (<<.GroupBy>>))
+  metricsQuery: <<.Series>>{<<.LabelMatchers>>}
+
+# Expose any recorded metrics following the standard service convention
+- seriesQuery: '{__name__=~"^svc:.*:.*$",service!=""}'
+  resources:
+    overrides:
+      namespace:
+        resource: namespace
+      service:
+        resource: service
+  name:
+    matches: "^svc:([^:]*):([^:]*)$"
+    as: "${1}_${2}"
+  metricsQuery: <<.Series>>{<<.LabelMatchers>>}
 
 # Expose total requests (ie istio_requests_total)
 - seriesQuery: '{__name__=~".*_requests_total$",pod!=""}'

--- a/common/workload-platform/README.md
+++ b/common/workload-platform/README.md
@@ -67,7 +67,7 @@ Installs the components necessary for running workloads:
 | <a name="input_istio_version"></a> [istio\_version](#input\_istio\_version) | Version of Istio to install | `string` | `"1.10.0"` | no |
 | <a name="input_pagerduty_routing_key"></a> [pagerduty\_routing\_key](#input\_pagerduty\_routing\_key) | Routing key for delivering Pagerduty alerts | `string` | `null` | no |
 | <a name="input_prometheus_adapter_values"></a> [prometheus\_adapter\_values](#input\_prometheus\_adapter\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
-| <a name="input_prometheus_adapter_version"></a> [prometheus\_adapter\_version](#input\_prometheus\_adapter\_version) | Version of external-dns to install | `string` | `"2.14.1"` | no |
+| <a name="input_prometheus_adapter_version"></a> [prometheus\_adapter\_version](#input\_prometheus\_adapter\_version) | Version of prometheus adapter to install | `string` | `"2.17.0"` | no |
 | <a name="input_prometheus_operator_values"></a> [prometheus\_operator\_values](#input\_prometheus\_operator\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_prometheus_operator_version"></a> [prometheus\_operator\_version](#input\_prometheus\_operator\_version) | Version of external-dns to install | `string` | `"16.0.1"` | no |
 | <a name="input_secret_store_driver_values"></a> [secret\_store\_driver\_values](#input\_secret\_store\_driver\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |


### PR DESCRIPTION
Every time series in Prometheus scraped from a service is tagged with a "service" label[1]. This adds queries for metrics that are pre-aggregated for a Kubernetes service and associates them with the corresponding Kubernetes object.

This is useful for autoscaling metrics based on quantiles, which don't make sense as a target for averageValue.

[1]: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#service
