### PR TITLE
Destroy target group binding before controller

### DIFF
--- a/aws/load-balancer-controller/main.tf
+++ b/aws/load-balancer-controller/main.tf
@@ -43,6 +43,8 @@ resource "helm_release" "ingress_config" {
       targetGroupARN = data.aws_lb_target_group.this.arn
     })
   ]
+
+  depends_on = [helm_release.this]
 }
 
 data "aws_lb_target_group" "this" {


### PR DESCRIPTION
If the controller is destroyed before the target group binding, it leaves a resource in the cluster that needs to be cleaned up manually before the workload platform can be destroyed.
