### PR TITLE
Move subnet data source out of node group

### DIFF
--- a/aws/cluster/README.md
+++ b/aws/cluster/README.md
@@ -45,6 +45,7 @@ An [OIDC provider](../k8s-oidc-provider) is configured to enable [IRSA].
 |------|------|
 | [aws_ssm_parameter.node_role_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.oidc_issuer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 
 ## Inputs
 

--- a/aws/cluster/main.tf
+++ b/aws/cluster/main.tf
@@ -45,7 +45,7 @@ module "node_groups" {
   name           = each.key
   namespace      = [module.cluster_name.full]
   role           = module.node_role.instance
-  subnet_ids     = module.network.private_subnet_ids
+  subnets        = values(data.aws_subnet.private)
   tags           = var.tags
 
   depends_on = [module.node_role]
@@ -67,4 +67,10 @@ resource "aws_ssm_parameter" "node_role_arn" {
   name  = join("/", concat(["", "flightdeck", module.cluster_name.full, "node_role_arn"]))
   type  = "SecureString"
   value = module.node_role.arn
+}
+
+data "aws_subnet" "private" {
+  for_each = module.network.private_subnet_ids
+
+  id = each.value
 }

--- a/aws/eks-node-group/README.md
+++ b/aws/eks-node-group/README.md
@@ -21,7 +21,6 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_eks_node_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group) | resource |
-| [aws_subnet.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 
 ## Inputs
 
@@ -34,7 +33,7 @@ No modules.
 | <a name="input_name"></a> [name](#input\_name) | Name for this EKS node group | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Prefix to be applied to created resources | `list(string)` | `[]` | no |
 | <a name="input_role"></a> [role](#input\_role) | IAM role nodes in this group will assume | `object({ arn = string })` | n/a | yes |
-| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnets in which the node group should run | `list(string)` | n/a | yes |
+| <a name="input_subnets"></a> [subnets](#input\_subnets) | Subnets in which the node group should run | `list(object({ id = string, availability_zone = string }))` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to created resources | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/aws/eks-node-group/main.tf
+++ b/aws/eks-node-group/main.tf
@@ -22,18 +22,12 @@ resource "aws_eks_node_group" "this" {
   }
 }
 
-data "aws_subnet" "this" {
-  for_each = toset(var.subnet_ids)
-
-  id = each.value
-}
-
 locals {
   min_size_per_node_group = ceil(var.min_size / 2)
   max_size_per_node_group = ceil(var.max_size / 2)
 
   subnets = zipmap(
-    values(data.aws_subnet.this).*.availability_zone,
-    values(data.aws_subnet.this)
+    var.subnets.*.availability_zone,
+    var.subnets
   )
 }

--- a/aws/eks-node-group/variables.tf
+++ b/aws/eks-node-group/variables.tf
@@ -35,8 +35,8 @@ variable "role" {
   description = "IAM role nodes in this group will assume"
 }
 
-variable "subnet_ids" {
-  type        = list(string)
+variable "subnets" {
+  type        = list(object({ id = string, availability_zone = string }))
   description = "Subnets in which the node group should run"
 }
 


### PR DESCRIPTION
Moving this data source outside of the module in which it's used allows Terraform to fetch the value before generating a plan, preventing errors with for_each.

Resolves #37.
