### PR TITLE
Add two prometheus replicas for high availability

### DIFF
--- a/common/workload-platform/flightdeck-prometheus.yaml
+++ b/common/workload-platform/flightdeck-prometheus.yaml
@@ -1,3 +1,13 @@
+prometheus:
+  spec:
+    replicas: 2
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: "topology.kubernetes.io/zone"
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            prometheus: flightdeck-prometheus
 podMonitors:
 - name: envoy-stats-monitor
   additionalLabels:


### PR DESCRIPTION
flightdeck-prometheus is used for autoscaling as well, so if this goes
down for whatever reason or whatever node, then it would cause the site
to suffer performance problems. We can mitigate this risk by having
multiple nodes.

This also means currently our federated instance is getting twice as
much data, since it's pulling from both replicas and not being
deduplicated yet.