### PR TITLE
Add vertical pod autoscaler for Prometheus

### DIFF
--- a/common/prometheus-instance/chart/templates/_helpers.tpl
+++ b/common/prometheus-instance/chart/templates/_helpers.tpl
@@ -24,6 +24,27 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Create a fully qualified stateful set name.
+https://github.com/prometheus-operator/prometheus-operator/blob/main/pkg/prometheus/statefulset.go#L86
+*/}}
+{{- define "prometheus.statefulsetname" -}}
+{{- if (eq .shard 0) }}
+{{- include "prometheus.statefulsetbase" . }}
+{{- else }}
+{{- printf "%s-shard-%d" (include "prometheus.statefulsetbase" . | trunc 63 | trimSuffix "-") .shard }}
+{{- end }}
+{{- end }}
+
+
+{{/*
+Create a stateful set name without shard.
+*/}}
+{{- define "prometheus.statefulsetbase" -}}
+{{- printf "prometheus-%s" (include "prometheus.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "prometheus.chart" -}}

--- a/common/prometheus-instance/chart/templates/vpa.yaml
+++ b/common/prometheus-instance/chart/templates/vpa.yaml
@@ -1,0 +1,25 @@
+{{ range $shard := (until (int .Values.prometheus.spec.shards)) }}
+---
+{{ with (merge $ (dict "shard" $shard)) }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+metadata:
+  name: {{ template "prometheus.statefulsetname" . }}
+  labels:
+    {{- include "prometheus.labels" . | nindent 4 }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: {{ template "prometheus.statefulsetname" . }}
+  updatePolicy:
+    updateMode: Auto
+  resourcePolicy:
+    containerPolicies:
+    - containerName: "*"
+      maxAllowed:
+        cpu: 2000m
+        memory: 8Gi
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
Prometheus uses a large amount of memory and is difficult to predict ahead of time. Using a vertical pod autoscaler will set resource requests dynamically to ensure Prometheus pods can be scheduled and are less likely to be evicted.
