### PR TITLE
Use filter method to retrieve VPC details 

### DIFF
--- a/aws/network-data/main.tf
+++ b/aws/network-data/main.tf
@@ -1,5 +1,11 @@
 data "aws_vpc" "this" {
-  tags = merge(var.tags, var.vpc_tags)
+  dynamic "filter" {
+    for_each = merge(var.tags, var.vpc_tags)
+      content {
+        name = "tag:${filter.key}"
+        values = [filter.value]
+    }
+  }
 }
 
 data "aws_subnet_ids" "private" {


### PR DESCRIPTION
This is the proposed method to solve an error with the VPC data resource in the `network-data` module failing to query the full tag value because it was referencing only the tags were already passed to the data resource block. 

