### PR TITLE
Use high availability Prometheus with deduplication

### DIFF
--- a/common/prometheus-instance/chart/templates/prometheus.yaml
+++ b/common/prometheus-instance/chart/templates/prometheus.yaml
@@ -28,6 +28,8 @@ spec:
     {{ toYaml . | indent 4 | trim }}
   {{- end }}
   portName: {{ .Values.prometheus.spec.portName }}
+  prometheusExternalLabelName: {{ .Values.prometheus.spec.prometheusExternalLabelName | quote }}
+  replicaExternalLabelName: {{ .Values.prometheus.spec.replicaExternalLabelName | quote }}
   replicas: {{ .Values.prometheus.spec.replicas }}
   version: {{ .Values.prometheus.spec.version }}
   serviceAccountName: {{ template "prometheus.fullname" . }}

--- a/common/prometheus-instance/chart/values.yaml
+++ b/common/prometheus-instance/chart/values.yaml
@@ -26,6 +26,8 @@ prometheus:
     podMonitorNamespaceSelector: {}
     portName: web
     probeNamespaceSelector: {}
+    prometheusExternalLabelName: ""
+    replicaExternalLabelName: ""
     replicas: 1
     retention: 24h
     ruleNamespaceSelector: {}

--- a/common/prometheus-operator/main.tf
+++ b/common/prometheus-operator/main.tf
@@ -82,7 +82,9 @@ locals {
             }
           }
 
-          retention = "24h"
+          replicaExternalLabelNameClear = true
+          replicas                      = 2
+          retention                     = "24h"
 
           resources = {
             requests = {

--- a/common/workload-platform/federated-prometheus.yaml
+++ b/common/workload-platform/federated-prometheus.yaml
@@ -12,3 +12,8 @@ prometheus:
       - targets:
         - 'kube-prometheus-stack-prometheus.kube-prometheus-stack.svc:9090'
         - 'flightdeck-prometheus.kube-prometheus-stack.svc:9090'
+
+    # https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-ingest-dedupe.html
+    prometheusExternalLabelName: cluster
+    replicaExternalLabelName: __replica__
+    replicas: 2


### PR DESCRIPTION
- Add another replica for kube-promethue-stack, federated-prometheus
- Set external labels for federated-prometheus for remote write
- Disable external labels for flightdeck-prometheus
- Disable external replica label for kube-prometheus-stack
