### PR TITLE
Remove SNS topic from network module

### DIFF
--- a/aws/cluster/README.md
+++ b/aws/cluster/README.md
@@ -51,7 +51,6 @@ An [OIDC provider](../k8s-oidc-provider) is configured to enable [IRSA].
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_alarm_topic_name"></a> [alarm\_topic\_name](#input\_alarm\_topic\_name) | Name of the SNS topic to which alarms should be sent | `string` | `null` | no |
 | <a name="input_enabled_cluster_log_types"></a> [enabled\_cluster\_log\_types](#input\_enabled\_cluster\_log\_types) | Which EKS control plane log types to enable | `list(string)` | `[]` | no |
 | <a name="input_k8s_version"></a> [k8s\_version](#input\_k8s\_version) | Kubernetes version to deploy | `string` | n/a | yes |
 | <a name="input_log_retention_in_days"></a> [log\_retention\_in\_days](#input\_log\_retention\_in\_days) | How many days until control plane logs are purged | `number` | `7` | no |

--- a/aws/cluster/main.tf
+++ b/aws/cluster/main.tf
@@ -8,10 +8,9 @@ module "cluster_name" {
 module "network" {
   source = "../network-data"
 
-  alarm_topic_name = var.alarm_topic_name
-  private_tags     = module.cluster_name.private_tags
-  public_tags      = module.cluster_name.public_tags
-  tags             = module.cluster_name.shared_tags
+  private_tags = module.cluster_name.private_tags
+  public_tags  = module.cluster_name.public_tags
+  tags         = module.cluster_name.shared_tags
 }
 
 module "eks_cluster" {

--- a/aws/cluster/variables.tf
+++ b/aws/cluster/variables.tf
@@ -1,9 +1,3 @@
-variable "alarm_topic_name" {
-  type        = string
-  description = "Name of the SNS topic to which alarms should be sent"
-  default     = null
-}
-
 variable "enabled_cluster_log_types" {
   type        = list(string)
   default     = []

--- a/aws/ingress/README.md
+++ b/aws/ingress/README.md
@@ -32,8 +32,8 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_alarm_actions"></a> [alarm\_actions](#input\_alarm\_actions) | SNS topics or other actions to invoke for alarms | `list(object({ arn = string }))` | `[]` | no |
 | <a name="input_alarm_evaluation_minutes"></a> [alarm\_evaluation\_minutes](#input\_alarm\_evaluation\_minutes) | Number of minutes of alarm state until triggering an alarm | `number` | `2` | no |
-| <a name="input_alarm_topic_name"></a> [alarm\_topic\_name](#input\_alarm\_topic\_name) | Name of the SNS topic to which alarms should be sent | `string` | `null` | no |
 | <a name="input_alternative_domain_names"></a> [alternative\_domain\_names](#input\_alternative\_domain\_names) | Alternative domain names for the ALB | `list(string)` | `[]` | no |
 | <a name="input_cluster_names"></a> [cluster\_names](#input\_cluster\_names) | List of clusters that this ingress stack will forward to | `list(string)` | n/a | yes |
 | <a name="input_create_aliases"></a> [create\_aliases](#input\_create\_aliases) | Set to false to disable creation of Route 53 aliases | `bool` | `true` | no |

--- a/aws/ingress/main.tf
+++ b/aws/ingress/main.tf
@@ -2,7 +2,7 @@ module "alb" {
   providers = { aws.cluster = aws.cluster, aws.route53 = aws.route53 }
   source    = "git@github.com:thoughtbot/terraform-alb-ingress.git?ref=v0.4.0"
 
-  alarm_actions             = module.network.alarm_actions
+  alarm_actions             = var.alarm_actions
   alarm_evaluation_minutes  = var.alarm_evaluation_minutes
   alternative_domain_names  = var.alternative_domain_names
   create_aliases            = var.create_aliases
@@ -28,8 +28,7 @@ module "alb" {
 module "network" {
   source = "../network-data"
 
-  alarm_topic_name = var.alarm_topic_name
-  tags             = merge(local.cluster_tags, var.network_tags)
+  tags = merge(local.cluster_tags, var.network_tags)
 }
 
 module "cluster_name" {

--- a/aws/ingress/variables.tf
+++ b/aws/ingress/variables.tf
@@ -4,10 +4,10 @@ variable "alarm_evaluation_minutes" {
   description = "Number of minutes of alarm state until triggering an alarm"
 }
 
-variable "alarm_topic_name" {
-  type        = string
-  description = "Name of the SNS topic to which alarms should be sent"
-  default     = null
+variable "alarm_actions" {
+  type        = list(object({ arn = string }))
+  description = "SNS topics or other actions to invoke for alarms"
+  default     = []
 }
 
 variable "alternative_domain_names" {

--- a/aws/network-data/README.md
+++ b/aws/network-data/README.md
@@ -20,7 +20,6 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_sns_topic.alarms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/sns_topic) | data source |
 | [aws_subnet_ids.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
 | [aws_subnet_ids.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
 | [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
@@ -29,7 +28,6 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_alarm_topic_name"></a> [alarm\_topic\_name](#input\_alarm\_topic\_name) | Name of the SNS topic to which alarms should be sent | `string` | `null` | no |
 | <a name="input_private_tags"></a> [private\_tags](#input\_private\_tags) | Tags to identify private subnets | `map(string)` | <pre>{<br>  "kubernetes.io/role/internal-elb": "1"<br>}</pre> | no |
 | <a name="input_public_tags"></a> [public\_tags](#input\_public\_tags) | Tags to identify public subnets | `map(string)` | <pre>{<br>  "kubernetes.io/role/elb": "1"<br>}</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to identify all resources | `map(string)` | `{}` | no |
@@ -39,7 +37,6 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_alarm_actions"></a> [alarm\_actions](#output\_alarm\_actions) | AWS actions invoked on alarms in this network |
 | <a name="output_cidr_blocks"></a> [cidr\_blocks](#output\_cidr\_blocks) | CIDR blocks allowed in this network |
 | <a name="output_cluster_names"></a> [cluster\_names](#output\_cluster\_names) | List of clusters which run in this network |
 | <a name="output_private_subnet_ids"></a> [private\_subnet\_ids](#output\_private\_subnet\_ids) | Private subnets for this network |

--- a/aws/network-data/main.tf
+++ b/aws/network-data/main.tf
@@ -12,14 +12,6 @@ data "aws_subnet_ids" "public" {
   vpc_id = data.aws_vpc.this.id
 }
 
-data "aws_sns_topic" "alarms" {
-  name = (
-    var.alarm_topic_name == null ?
-    "${data.aws_vpc.this.tags.Name}-alarms" :
-    var.alarm_topic_name
-  )
-}
-
 locals {
   cluster_names = [
     for tag in keys(data.aws_vpc.this.tags) :

--- a/aws/network-data/outputs.tf
+++ b/aws/network-data/outputs.tf
@@ -1,8 +1,3 @@
-output "alarm_actions" {
-  description = "AWS actions invoked on alarms in this network"
-  value       = [data.aws_sns_topic.alarms]
-}
-
 output "cluster_names" {
   description = "List of clusters which run in this network"
   value       = local.cluster_names

--- a/aws/network-data/variables.tf
+++ b/aws/network-data/variables.tf
@@ -1,9 +1,3 @@
-variable "alarm_topic_name" {
-  type        = string
-  description = "Name of the SNS topic to which alarms should be sent"
-  default     = null
-}
-
 variable "private_tags" {
   description = "Tags to identify private subnets"
   type        = map(string)

--- a/aws/network/README.md
+++ b/aws/network/README.md
@@ -44,7 +44,6 @@ An [OIDC provider](../k8s-oidc-provider) is configured to enable [IRSA].
 | Name | Type |
 |------|------|
 | [aws_internet_gateway.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/internet_gateway) | resource |
-| [aws_sns_topic.alarms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
 | [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
 ## Inputs

--- a/aws/network/main.tf
+++ b/aws/network/main.tf
@@ -91,11 +91,6 @@ resource "aws_internet_gateway" "this" {
   vpc_id = local.vpc.id
 }
 
-resource "aws_sns_topic" "alarms" {
-  name = join("-", concat(var.namespace, [var.name, "alarms"]))
-  tags = var.tags
-}
-
 locals {
   vpc_tags = merge(var.tags, local.cluster_tags, var.vpc_tags)
   vpc      = var.create_vpc ? module.vpc[0].instance : data.aws_vpc.this[0]

--- a/aws/workload-platform/README.md
+++ b/aws/workload-platform/README.md
@@ -53,7 +53,6 @@ Cluster Autoscaler, and ExternalDNS.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_admin_roles"></a> [admin\_roles](#input\_admin\_roles) | Additional IAM roles which have admin cluster privileges | `list(string)` | `[]` | no |
-| <a name="input_alarm_topic_name"></a> [alarm\_topic\_name](#input\_alarm\_topic\_name) | Name of the SNS topic to which alarms should be sent | `string` | `null` | no |
 | <a name="input_aws_load_balancer_controller_values"></a> [aws\_load\_balancer\_controller\_values](#input\_aws\_load\_balancer\_controller\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_aws_load_balancer_controller_version"></a> [aws\_load\_balancer\_controller\_version](#input\_aws\_load\_balancer\_controller\_version) | Version of aws-load-balancer-controller to install | `string` | `null` | no |
 | <a name="input_aws_namespace"></a> [aws\_namespace](#input\_aws\_namespace) | Prefix to be applied to created AWS resources | `list(string)` | `[]` | no |

--- a/aws/workload-platform/main.tf
+++ b/aws/workload-platform/main.tf
@@ -85,10 +85,9 @@ module "cluster_name" {
 module "network" {
   source = "../network-data"
 
-  alarm_topic_name = var.alarm_topic_name
-  private_tags     = module.cluster_name.private_tags
-  public_tags      = module.cluster_name.public_tags
-  tags             = module.cluster_name.shared_tags
+  private_tags = module.cluster_name.private_tags
+  public_tags  = module.cluster_name.public_tags
+  tags         = module.cluster_name.shared_tags
 }
 
 module "auth_config_map" {

--- a/aws/workload-platform/variables.tf
+++ b/aws/workload-platform/variables.tf
@@ -4,12 +4,6 @@ variable "admin_roles" {
   default     = []
 }
 
-variable "alarm_topic_name" {
-  type        = string
-  description = "Name of the SNS topic to which alarms should be sent"
-  default     = null
-}
-
 variable "aws_load_balancer_controller_values" {
   description = "Overrides to pass to the Helm chart"
   type        = list(string)


### PR DESCRIPTION
We currently create an SNS topic for alarms in the network module and then attempt to find that topic based on tags or name in other modules. This has always been an awkward place to create it, and in most Flightdeck deployments we've actually used an existing topic.

This removes the topic that gets created in the network module. The only place it's actually required in Flightdeck is for ingress. The ingress module now accepts the same list of alarm actions that the underlying ALB module requires.
