### PR TITLE
Add acceptance test workflow

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -51,11 +51,20 @@ jobs:
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
 
+  tests:
+    name: Run Tests
+    uses: ./.github/workflows/tests.yaml
+    needs:
+    - apply_platform
+    concurrency: ${{ github.ref_name }}-platform
+    secrets:
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+
   cleanup_platform:
     name: Cleanup Platform
     uses: ./.github/workflows/terraform.yaml
     needs:
-    - apply_platform
+    - tests
     concurrency: ${{ github.ref_name }}-platform
     with:
       module: platform/sandbox-v1

--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -2,9 +2,100 @@ name: Acceptance
 on:
 - workflow_dispatch
 
+permissions:
+  id-token: write
+  contents: read
+  checks: write
+
 jobs:
   apply_network:
     name: Apply Network
-    runs-on: ubuntu-20.04
-    steps:
-    - run: echo ok
+    uses: ./.github/workflows/terraform.yaml
+    concurrency: ${{ github.ref_name }}-network
+    with:
+      module: network/sandbox
+    secrets:
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+
+  apply_cluster:
+    name: Apply Cluster
+    uses: ./.github/workflows/terraform.yaml
+    needs:
+    - apply_network
+    concurrency: ${{ github.ref_name }}-cluster
+    with:
+      module: cluster/sandbox-v1
+    secrets:
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+
+  apply_ingress:
+    name: Apply Ingress
+    uses: ./.github/workflows/terraform.yaml
+    needs:
+    - apply_network
+    concurrency: ${{ github.ref_name }}-ingress
+    with:
+      module: ingress/sandbox
+    secrets:
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+
+  apply_platform:
+    name: Apply Platform
+    uses: ./.github/workflows/terraform.yaml
+    needs:
+    - apply_cluster
+    - apply_ingress
+    concurrency: ${{ github.ref_name }}-platform
+    with:
+      module: platform/sandbox-v1
+    secrets:
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+
+  cleanup_platform:
+    name: Cleanup Platform
+    uses: ./.github/workflows/terraform.yaml
+    needs:
+    - apply_platform
+    concurrency: ${{ github.ref_name }}-platform
+    with:
+      module: platform/sandbox-v1
+      terraform_command: destroy
+    secrets:
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+
+  cleanup_ingress:
+    name: Cleanup Ingress
+    uses: ./.github/workflows/terraform.yaml
+    needs:
+    - cleanup_platform
+    concurrency: ${{ github.ref_name }}-ingress
+    with:
+      module: ingress/sandbox
+      terraform_command: destroy
+    secrets:
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+
+  cleanup_cluster:
+    name: Cleanup Cluster
+    uses: ./.github/workflows/terraform.yaml
+    needs:
+    - cleanup_platform
+    concurrency: ${{ github.ref_name }}-cluster
+    with:
+      module: cluster/sandbox-v1
+      terraform_command: destroy
+    secrets:
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+
+  cleanup_network:
+    name: Cleanup Network
+    uses: ./.github/workflows/terraform.yaml
+    needs:
+    - cleanup_ingress
+    - cleanup_cluster
+    concurrency: ${{ github.ref_name }}-network
+    with:
+      module: network/sandbox
+      terraform_command: destroy
+    secrets:
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -1,0 +1,80 @@
+name: Terraform
+on:
+  workflow_call:
+    inputs:
+      module:
+        type: string
+        required: true
+      terraform_command:
+        type: string
+        default: apply
+      terraform_version:
+        default: 1.0.11
+        type: string
+    secrets:
+      AWS_ACCOUNT_ID:
+        description: AWS account in which Terraform will run
+        required: true
+
+jobs:
+  plan:
+    name: Terraform
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        shell: bash
+        working-directory: ${{ inputs.module }}
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        repository: thoughtbot/flightdeck-template
+        path: template
+
+    - name: Configure repository
+      working-directory: template
+      run: |
+        bin/set-flightdeck-version ${{ github.ref_name }}
+        bin/uncomment certificate_domain_name
+        bin/uncomment issue_certificates
+        bin/set-template-var ACCOUNT_ID ${{ secrets.AWS_ACCOUNT_ID }}
+        bin/set-template-var ORG_NAME flightdeck
+        bin/set-template-var REGION us-east-1
+        bin/set-template-var STATE_PREFIX ${{ github.ref_name }}
+        bin/set-template-var SANDBOX_ACCOUNT_ID ${{ secrets.AWS_ACCOUNT_ID }}
+        bin/set-template-var SANDBOX_CERTIFICATE_DOMAIN_NAME flightdeck-test.thoughtbot.com
+        bin/set-template-var SANDBOX_DOMAIN_NAME ${{ github.ref_name }}.flightdeck-test.thoughtbot.com
+        bin/set-template-var SANDBOX_EXECUTION_ROLE flightdeck-ci-execution
+        bin/set-template-var SANDBOX_HOSTED_ZONE flightdeck-test.thoughtbot.com
+        bin/set-template-var SANDBOX_STATE_BUCKET flightdeck-ci-state
+        bin/set-template-var SANDBOX_STATE_TABLE flightdeck-ci-state
+        bin/set-template-var SANDBOX_STATE_KMS_KEY flightdeck-ci-state
+        bin/set-template-var SANDBOX_STATE_ROLE flightdeck-ci-state
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-region: us-east-1
+        role-to-assume: "arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/flightdeck-ci"
+
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v1
+      with:
+        terraform_version: ${{ inputs.terraform_version }}
+
+    - name: Setup Node
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+
+    - name: Init
+      working-directory: template/${{ inputs.module }}
+      run: terraform init
+
+    - name: Run
+      working-directory: template/${{ inputs.module }}
+      run: |
+        terraform ${{ inputs.terraform_command }} -auto-approve
+

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,65 @@
+name: Tests
+on:
+  workflow_call:
+    secrets:
+      AWS_ACCOUNT_ID:
+        description: AWS account in which tests will run
+        required: true
+
+env:
+  KUBECONFIG: /tmp/kubeconfig
+
+jobs:
+  plan:
+    name: Test
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-region: us-east-1
+        role-to-assume: "arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/flightdeck-ci"
+
+    - name: Assume execution role
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
+        aws-region: us-east-1
+        aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+        aws-session-token: ${{ env.AWS_SESSION_TOKEN }}
+        role-duration-seconds: 3000
+        role-skip-session-tagging: true
+        role-to-assume: "arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/flightdeck-ci-execution"
+
+    - name: Set up Kubernetes context
+      run: |
+        aws \
+          --region us-east-1 \
+          eks \
+          update-kubeconfig \
+          --name flightdeck-sandbox-v1
+
+    - name: Build manifests
+      id: kustomize
+      uses: azure/k8s-bake@v1
+      with:
+        renderEngine: kustomize
+        kustomizationPath: tests/manifests
+
+    - name: Deploy test app
+      uses: Azure/k8s-deploy@v1.4
+      with:
+        manifests: ${{ steps.kustomize.outputs.manifestsBundle }}
+        namespace: acceptance
+
+    - name: Run tests
+      run: |
+        make tests ADDRESS=https://${{ github.ref_name }}.flightdeck-test.thoughtbot.com

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ applied
 dependencies
 dist
 initialized
+tmp
+vendor

--- a/aws/cluster-name/makefile
+++ b/aws/cluster-name/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/aws/cluster/makefile
+++ b/aws/cluster/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/aws/cluster/modules/eks-cluster/makefile
+++ b/aws/cluster/modules/eks-cluster/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/aws/cluster/modules/eks-node-group/makefile
+++ b/aws/cluster/modules/eks-node-group/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/aws/cluster/modules/eks-node-role/makefile
+++ b/aws/cluster/modules/eks-node-role/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/aws/cluster/modules/k8s-oidc-provider/makefile
+++ b/aws/cluster/modules/k8s-oidc-provider/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/aws/ingress/README.md
+++ b/aws/ingress/README.md
@@ -101,7 +101,7 @@ module "ingress" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_alb"></a> [alb](#module\_alb) | github.com/thoughtbot/terraform-alb-ingress | v0.4.0 |
+| <a name="module_alb"></a> [alb](#module\_alb) | github.com/thoughtbot/terraform-alb-ingress | 131b6f8 |
 | <a name="module_cluster_name"></a> [cluster\_name](#module\_cluster\_name) | ../cluster-name | n/a |
 | <a name="module_network"></a> [network](#module\_network) | ../network-data | n/a |
 
@@ -112,6 +112,7 @@ module "ingress" {
 | <a name="input_alarm_actions"></a> [alarm\_actions](#input\_alarm\_actions) | SNS topics or other actions to invoke for alarms | `list(object({ arn = string }))` | `[]` | no |
 | <a name="input_alarm_evaluation_minutes"></a> [alarm\_evaluation\_minutes](#input\_alarm\_evaluation\_minutes) | Number of minutes of alarm state until triggering an alarm | `number` | `2` | no |
 | <a name="input_alternative_domain_names"></a> [alternative\_domain\_names](#input\_alternative\_domain\_names) | Alternative domain names for the ALB | `list(string)` | `[]` | no |
+| <a name="input_certificate_domain_name"></a> [certificate\_domain\_name](#input\_certificate\_domain\_name) | Override the domain name for the ACM certificate (defaults to primary domain) | `string` | `null` | no |
 | <a name="input_cluster_names"></a> [cluster\_names](#input\_cluster\_names) | List of clusters that this ingress stack will forward to | `list(string)` | n/a | yes |
 | <a name="input_create_aliases"></a> [create\_aliases](#input\_create\_aliases) | Set to false to disable creation of Route 53 aliases | `bool` | `true` | no |
 | <a name="input_failure_threshold"></a> [failure\_threshold](#input\_failure\_threshold) | Percentage of failed requests considered an anomaly | `number` | `5` | no |

--- a/aws/ingress/main.tf
+++ b/aws/ingress/main.tf
@@ -1,10 +1,11 @@
 module "alb" {
   providers = { aws.cluster = aws.cluster, aws.route53 = aws.route53 }
-  source    = "github.com/thoughtbot/terraform-alb-ingress?ref=v0.4.0"
+  source    = "github.com/thoughtbot/terraform-alb-ingress?ref=131b6f8"
 
   alarm_actions             = var.alarm_actions
   alarm_evaluation_minutes  = var.alarm_evaluation_minutes
   alternative_domain_names  = var.alternative_domain_names
+  certificate_domain_name   = var.certificate_domain_name
   create_aliases            = var.create_aliases
   description               = "Flightdeck cluster load balancer"
   failure_threshold         = var.failure_threshold

--- a/aws/ingress/makefile
+++ b/aws/ingress/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/aws/ingress/variables.tf
+++ b/aws/ingress/variables.tf
@@ -16,6 +16,12 @@ variable "alternative_domain_names" {
   description = "Alternative domain names for the ALB"
 }
 
+variable "certificate_domain_name" {
+  type        = string
+  default     = null
+  description = "Override the domain name for the ACM certificate (defaults to primary domain)"
+}
+
 variable "cluster_names" {
   type        = list(string)
   description = "List of clusters that this ingress stack will forward to"

--- a/aws/network-data/makefile
+++ b/aws/network-data/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/aws/network/makefile
+++ b/aws/network/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/aws/network/modules/nat-gateway/makefile
+++ b/aws/network/modules/nat-gateway/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/aws/network/modules/private-subnet-routes/makefile
+++ b/aws/network/modules/private-subnet-routes/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/aws/network/modules/private-subnets/makefile
+++ b/aws/network/modules/private-subnets/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/aws/network/modules/public-subnet-routes/makefile
+++ b/aws/network/modules/public-subnet-routes/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/aws/network/modules/public-subnets/makefile
+++ b/aws/network/modules/public-subnets/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/aws/network/modules/vpc/makefile
+++ b/aws/network/modules/vpc/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/aws/platform/makefile
+++ b/aws/platform/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/aws/platform/modules/auth-config-map/makefile
+++ b/aws/platform/modules/auth-config-map/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/aws/platform/modules/cloudwatch-logs/makefile
+++ b/aws/platform/modules/cloudwatch-logs/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/aws/platform/modules/cluster-autoscaler-service-account-role/makefile
+++ b/aws/platform/modules/cluster-autoscaler-service-account-role/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/aws/platform/modules/dns-service-account-role/makefile
+++ b/aws/platform/modules/dns-service-account-role/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/aws/platform/modules/load-balancer-controller/main.tf
+++ b/aws/platform/modules/load-balancer-controller/main.tf
@@ -5,6 +5,11 @@ resource "helm_release" "this" {
   repository = coalesce(var.chart_repository, local.chart_defaults.repository)
   values     = concat(local.chart_values, var.chart_values)
   version    = coalesce(var.chart_version, local.chart_defaults.version)
+
+  # Ensure the role isn't detached until the chart is uninstalled. This prevents
+  # target group bindings from being orphaned when the finalizer is missing
+  # permissions.
+  depends_on = [aws_iam_role_policy_attachment.this]
 }
 
 resource "helm_release" "ingress_config" {

--- a/aws/platform/modules/load-balancer-controller/makefile
+++ b/aws/platform/modules/load-balancer-controller/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/aws/platform/modules/load-balancer-controller/providers.tf.json
+++ b/aws/platform/modules/load-balancer-controller/providers.tf.json
@@ -7,7 +7,7 @@
       },
       "helm": {
         "source": "hashicorp/helm",
-        "version": "~> 2.1.2"
+        "version": "~> 2.4"
       }
     }
   }

--- a/aws/platform/modules/prometheus-service-account-role/makefile
+++ b/aws/platform/modules/prometheus-service-account-role/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/aws/platform/modules/secrets-store-provider/makefile
+++ b/aws/platform/modules/secrets-store-provider/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/aws/platform/modules/secrets-store-provider/providers.tf.json
+++ b/aws/platform/modules/secrets-store-provider/providers.tf.json
@@ -4,7 +4,7 @@
     "required_providers": {
       "helm": {
         "source": "hashicorp/helm",
-        "version": "~> 2.1.2"
+        "version": "~> 2.4"
       }
     }
   }

--- a/aws/prometheus-workspace/makefile
+++ b/aws/prometheus-workspace/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/aws/service-account-policy/makefile
+++ b/aws/service-account-policy/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/aws/service-account-role/makefile
+++ b/aws/service-account-role/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/makefile
+++ b/makefile
@@ -17,6 +17,8 @@ SUBMODULEMAKEFILES := $(foreach module,$(SUBMODULES),$(module)/makefile)
 MAKESUBMODULES     := $(foreach module,$(SUBMODULES),$(module)/make)
 SUBMODULESCOMMAND  ?= default
 
+include makefiles/tests.mk
+
 .PHONY: default
 default: chartparams submodules
 

--- a/makefiles/terraform.mk
+++ b/makefiles/terraform.mk
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/makefiles/tests.mk
+++ b/makefiles/tests.mk
@@ -1,0 +1,20 @@
+TEST_FILES  := $(wildcard tests/*.bats)
+
+export TEST_TMPDIR := $(CURDIR)/tmp
+export TEST_DIR    := $(CURDIR)/tests
+
+.PHONY: tests
+tests: vendor/bin/bats
+	vendor/bin/bats $(TEST_FILES)
+
+.PHONY: $(TEST_FILES)
+$(TEST_FILES): vendor/bin/bats
+	vendor/bin/bats "$@"
+
+vendor/bin/bats: tmp/bats
+	mkdir -p vendor
+	tmp/bats/install.sh ./vendor
+
+tmp/bats:
+	mkdir -p tmp
+	git clone https://github.com/sstephenson/bats.git tmp/bats

--- a/platform/makefile
+++ b/platform/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/platform/modules/cert-manager/makefile
+++ b/platform/modules/cert-manager/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/platform/modules/cert-manager/providers.tf.json
+++ b/platform/modules/cert-manager/providers.tf.json
@@ -4,7 +4,7 @@
     "required_providers": {
       "helm": {
         "source": "hashicorp/helm",
-        "version": "~> 2.1.2"
+        "version": "~> 2.4"
       }
     }
   }

--- a/platform/modules/cluster-autoscaler/makefile
+++ b/platform/modules/cluster-autoscaler/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/platform/modules/cluster-autoscaler/providers.tf.json
+++ b/platform/modules/cluster-autoscaler/providers.tf.json
@@ -4,7 +4,7 @@
     "required_providers": {
       "helm": {
         "source": "hashicorp/helm",
-        "version": "~> 2.1.2"
+        "version": "~> 2.4"
       }
     }
   }

--- a/platform/modules/external-dns/makefile
+++ b/platform/modules/external-dns/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/platform/modules/external-dns/providers.tf.json
+++ b/platform/modules/external-dns/providers.tf.json
@@ -4,7 +4,7 @@
     "required_providers": {
       "helm": {
         "source": "hashicorp/helm",
-        "version": "~> 2.1.2"
+        "version": "~> 2.4"
       }
     }
   }

--- a/platform/modules/fluent-bit/makefile
+++ b/platform/modules/fluent-bit/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/platform/modules/fluent-bit/providers.tf.json
+++ b/platform/modules/fluent-bit/providers.tf.json
@@ -4,7 +4,7 @@
     "required_providers": {
       "helm": {
         "source": "hashicorp/helm",
-        "version": "~> 2.1.2"
+        "version": "~> 2.4"
       }
     }
   }

--- a/platform/modules/ingress-config/makefile
+++ b/platform/modules/ingress-config/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/platform/modules/ingress-config/providers.tf.json
+++ b/platform/modules/ingress-config/providers.tf.json
@@ -4,7 +4,7 @@
     "required_providers": {
       "helm": {
         "source": "hashicorp/helm",
-        "version": "~> 2.1.2"
+        "version": "~> 2.4"
       }
     }
   }

--- a/platform/modules/istio-ingress/makefile
+++ b/platform/modules/istio-ingress/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/platform/modules/istio-ingress/providers.tf.json
+++ b/platform/modules/istio-ingress/providers.tf.json
@@ -4,7 +4,7 @@
     "required_providers": {
       "helm": {
         "source": "hashicorp/helm",
-        "version": "~> 2.1.2"
+        "version": "~> 2.4"
       }
     }
   }

--- a/platform/modules/istio/makefile
+++ b/platform/modules/istio/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/platform/modules/istio/providers.tf.json
+++ b/platform/modules/istio/providers.tf.json
@@ -4,7 +4,7 @@
     "required_providers": {
       "helm": {
         "source": "hashicorp/helm",
-        "version": "~> 2.1.2"
+        "version": "~> 2.4"
       }
     }
   }

--- a/platform/modules/metrics-server/makefile
+++ b/platform/modules/metrics-server/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/platform/modules/metrics-server/providers.tf.json
+++ b/platform/modules/metrics-server/providers.tf.json
@@ -4,7 +4,7 @@
     "required_providers": {
       "helm": {
         "source": "hashicorp/helm",
-        "version": "~> 2.1.2"
+        "version": "~> 2.4"
       }
     }
   }

--- a/platform/modules/prometheus-adapter/makefile
+++ b/platform/modules/prometheus-adapter/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/platform/modules/prometheus-adapter/providers.tf.json
+++ b/platform/modules/prometheus-adapter/providers.tf.json
@@ -4,7 +4,7 @@
     "required_providers": {
       "helm": {
         "source": "hashicorp/helm",
-        "version": "~> 2.1.2"
+        "version": "~> 2.4"
       }
     }
   }

--- a/platform/modules/prometheus-instance/makefile
+++ b/platform/modules/prometheus-instance/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/platform/modules/prometheus-instance/providers.tf.json
+++ b/platform/modules/prometheus-instance/providers.tf.json
@@ -4,7 +4,7 @@
     "required_providers": {
       "helm": {
         "source": "hashicorp/helm",
-        "version": "~> 2.1.2"
+        "version": "~> 2.4"
       },
       "random": {
         "version": "~> 3.1"

--- a/platform/modules/prometheus-operator/makefile
+++ b/platform/modules/prometheus-operator/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/platform/modules/prometheus-operator/providers.tf.json
+++ b/platform/modules/prometheus-operator/providers.tf.json
@@ -4,7 +4,7 @@
     "required_providers": {
       "helm": {
         "source": "hashicorp/helm",
-        "version": "~> 2.1.2"
+        "version": "~> 2.4"
       }
     }
   }

--- a/platform/modules/reloader/makefile
+++ b/platform/modules/reloader/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/platform/modules/reloader/providers.tf.json
+++ b/platform/modules/reloader/providers.tf.json
@@ -4,7 +4,7 @@
     "required_providers": {
       "helm": {
         "source": "hashicorp/helm",
-        "version": "~> 2.1.2"
+        "version": "~> 2.4"
       }
     }
   }

--- a/platform/modules/secret-store-driver/makefile
+++ b/platform/modules/secret-store-driver/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/platform/modules/secret-store-driver/providers.tf.json
+++ b/platform/modules/secret-store-driver/providers.tf.json
@@ -4,7 +4,7 @@
     "required_providers": {
       "helm": {
         "source": "hashicorp/helm",
-        "version": "~> 2.1.2"
+        "version": "~> 2.4"
       }
     }
   }

--- a/platform/modules/sloth/makefile
+++ b/platform/modules/sloth/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/platform/modules/sloth/providers.tf.json
+++ b/platform/modules/sloth/providers.tf.json
@@ -4,7 +4,7 @@
     "required_providers": {
       "helm": {
         "source": "hashicorp/helm",
-        "version": "~> 2.1.2"
+        "version": "~> 2.4"
       }
     }
   }

--- a/platform/modules/vertical-pod-autoscaler/makefile
+++ b/platform/modules/vertical-pod-autoscaler/makefile
@@ -64,4 +64,4 @@ init: .init
 
 .PHONY: clean
 clean:
-	rm -rf .dependencies .fmt .init .lint .lintinit .terraform .validate
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/platform/modules/vertical-pod-autoscaler/providers.tf.json
+++ b/platform/modules/vertical-pod-autoscaler/providers.tf.json
@@ -4,7 +4,7 @@
     "required_providers": {
       "helm": {
         "source": "hashicorp/helm",
-        "version": "~> 2.1.2"
+        "version": "~> 2.4"
       },
       "random": {
         "version": "~> 3.1"

--- a/tests/manifests/deployment.yaml
+++ b/tests/manifests/deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echoserver
+  namespace: acceptance
+spec:
+  selector:
+    matchLabels:
+      app: echoserver
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: echoserver
+    spec:
+      containers:
+      - image: gcr.io/google_containers/echoserver:1.4
+        imagePullPolicy: Always
+        name: echoserver
+        ports:
+        - containerPort: 8080

--- a/tests/manifests/kustomization.yaml
+++ b/tests/manifests/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- namespace.yaml
+- deployment.yaml
+- service.yaml
+- virtualservice.yaml
+
+namespace: acceptance

--- a/tests/manifests/namespace.yaml
+++ b/tests/manifests/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: acceptance
+  labels:
+    istio-injection: enabled

--- a/tests/manifests/service.yaml
+++ b/tests/manifests/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: echoserver
+  namespace: acceptance
+spec:
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+  type: NodePort
+  selector:
+    app: echoserver

--- a/tests/manifests/virtualservice.yaml
+++ b/tests/manifests/virtualservice.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: echoservice
+spec:
+  gateways:
+  - flightdeck/flightdeck
+  http:
+  - match:
+    - uri:
+        prefix: /echo
+    route:
+    - destination:
+        host: echoserver
+        port:
+          number: 80
+  hosts:
+  - "*"

--- a/tests/virtualservice.bats
+++ b/tests/virtualservice.bats
@@ -1,0 +1,9 @@
+#!/usr/bin/env bats
+
+@test "routes to the echo service" {
+  response=$(curl "$ADDRESS/echo?hello")
+  if ! echo "$response" | grep -q "query=hello"; then
+    echo "Invalid echo response:\n$response"
+    false
+  fi
+}


### PR DESCRIPTION
This adds a workflow which runs on-demand from the GitHub UI or CLI.

The workflow will apply the major AWS modules (network, cluster, ingress,
platform) and tear them down again.
