### PR TITLE
Fix Fluent Bit after Helm chart upgrade

### DIFF
--- a/aws/platform/main.tf
+++ b/aws/platform/main.tf
@@ -342,7 +342,7 @@ locals {
       ]
       image = {
         repository = "public.ecr.aws/aws-observability/aws-for-fluent-bit"
-        tag        = "2.12.0"
+        tag        = "2.22.0"
       }
       resources = {
         limits = {

--- a/tests/fluentbit.bats
+++ b/tests/fluentbit.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+
+@test "deploys fluent bit on each node" {
+  pods=$(kubectl \
+    --namespace flightdeck \
+    get pod \
+    --field-selector=status.phase=Running \
+    --selector=app.kubernetes.io/name=fluent-bit \
+    --output jsonpath='{range .items[*]}{.spec.nodeName}{"\n"}{end}' \
+    | sort)
+  nodes=$(kubectl \
+    --namespace flightdeck \
+    get node \
+    --output=name \
+    | sed 's|^node/||' \
+    | sort)
+
+  if [ "$pods" != "$nodes" ]; then
+    echo "Found nodes:" >&2
+    echo "$nodes" >&2
+    echo >&2
+    echo "Found Fluent Bit pods on nodes:" >&2
+    echo "$pods" >&2
+    echo "$pods" > /tmp/podlist
+    echo "$nodes" > /tmp/nodelist
+    echo >&2
+    echo "Difference:" >&2
+    diff /tmp/nodelist /tmp/podlist  >&2
+    false
+  fi
+}


### PR DESCRIPTION
After upgrading the Helm chart version, we also need to update the fluent bit version. This is because we're using the AWS fork of fluent bit which is hosted on AWS and builds in support for AWS plugins.

Also adds a new test to verify that at a fluent bit pod is running on each node.
