### PR TITLE
Add protections against accidental cluster lockout

### DIFF
--- a/aws/platform/modules/auth-config-map/README.md
+++ b/aws/platform/modules/auth-config-map/README.md
@@ -18,16 +18,27 @@
 
 | Name | Type |
 |------|------|
+| [aws_iam_role.breakglass](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.breakglass](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [null_resource.aws_auth_patch](https://registry.terraform.io/providers/hashicorp/null/3.1.0/docs/resources/resource) | resource |
+| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_eks_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
 | [aws_eks_cluster_auth.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
+| [aws_iam_policy_document.breakglass](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.breakglass_trust](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_admin_roles"></a> [admin\_roles](#input\_admin\_roles) | Role ARNs which have admin privileges within the cluster | `list(string)` | `[]` | no |
+| <a name="input_admin_roles"></a> [admin\_roles](#input\_admin\_roles) | Role ARNs which have admin privileges within the cluster | `list(string)` | n/a | yes |
 | <a name="input_cluster_full_name"></a> [cluster\_full\_name](#input\_cluster\_full\_name) | Full name of the EKS cluster | `string` | n/a | yes |
 | <a name="input_custom_roles"></a> [custom\_roles](#input\_custom\_roles) | Role ARNs which have custom privileges within the cluster | `map(string)` | `{}` | no |
-| <a name="input_node_roles"></a> [node\_roles](#input\_node\_roles) | Roles for EKS node groups in this cluster | `list(string)` | `[]` | no |
+| <a name="input_node_roles"></a> [node\_roles](#input\_node\_roles) | Roles for EKS node groups in this cluster | `list(string)` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_breakglass_role_arn"></a> [breakglass\_role\_arn](#output\_breakglass\_role\_arn) | ARN for a breakglass role in case of cluster lockout |
 <!-- END_TF_DOCS -->

--- a/aws/platform/modules/auth-config-map/outputs.tf
+++ b/aws/platform/modules/auth-config-map/outputs.tf
@@ -1,0 +1,4 @@
+output "breakglass_role_arn" {
+  description = "ARN for a breakglass role in case of cluster lockout"
+  value       = aws_iam_role.breakglass.arn
+}

--- a/aws/platform/modules/auth-config-map/variables.tf
+++ b/aws/platform/modules/auth-config-map/variables.tf
@@ -1,7 +1,11 @@
 variable "admin_roles" {
   type        = list(string)
-  default     = []
   description = "Role ARNs which have admin privileges within the cluster"
+
+  validation {
+    condition     = length(var.admin_roles) > 0
+    error_message = "Without an admin role, you will be unable to administrate the cluster."
+  }
 }
 
 variable "cluster_full_name" {
@@ -17,6 +21,10 @@ variable "custom_roles" {
 
 variable "node_roles" {
   type        = list(string)
-  default     = []
   description = "Roles for EKS node groups in this cluster"
+
+  validation {
+    condition     = length(var.node_roles) > 0
+    error_message = "Without a node role, no nodes can join the cluster."
+  }
 }

--- a/aws/platform/outputs.tf
+++ b/aws/platform/outputs.tf
@@ -1,0 +1,4 @@
+output "breakglass_role_arn" {
+  description = "ARN for a breakglass role in case of cluster lockout"
+  value       = module.auth_config_map.breakglass_role_arn
+}

--- a/aws/platform/variables.tf
+++ b/aws/platform/variables.tf
@@ -1,7 +1,6 @@
 variable "admin_roles" {
   type        = list(string)
   description = "Additional IAM roles which have admin cluster privileges"
-  default     = []
 }
 
 variable "aws_load_balancer_controller_values" {


### PR DESCRIPTION
If you don't pass any admin roles to the aws-auth module but you do include a non-admin mapping for the role that created the cluster, you can become permanently locked out of the cluster, requiring you to manually delete it and create a new one.

This adds several protections against this case:

- A validation is included to prevent passing an empty list of admin roles
- A validation is included to ensure at least one node role is set
- A dedicated "breakglass" role is created and added to the aws-auth config map which can be used in an emergency to regain access.
