### PR TITLE
Pass prometheus workspace datasource into platform module

### DIFF
--- a/aws/platform/README.md
+++ b/aws/platform/README.md
@@ -125,6 +125,7 @@ data "aws_eks_cluster" "this" {
 | <a name="input_aws_load_balancer_controller_values"></a> [aws\_load\_balancer\_controller\_values](#input\_aws\_load\_balancer\_controller\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_aws_load_balancer_controller_version"></a> [aws\_load\_balancer\_controller\_version](#input\_aws\_load\_balancer\_controller\_version) | Version of aws-load-balancer-controller to install | `string` | `null` | no |
 | <a name="input_aws_namespace"></a> [aws\_namespace](#input\_aws\_namespace) | Prefix to be applied to created AWS resources | `list(string)` | `[]` | no |
+| <a name="input_aws_prometheus_workspace_id"></a> [aws\_prometheus\_workspace\_id](#input\_aws\_prometheus\_workspace\_id) | Id for the prometheus workspace created in AWS | `string` | `null` | no |
 | <a name="input_aws_tags"></a> [aws\_tags](#input\_aws\_tags) | Tags to be applied to created AWS resources | `map(string)` | `{}` | no |
 | <a name="input_cert_manager_values"></a> [cert\_manager\_values](#input\_cert\_manager\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_certificate_issuer"></a> [certificate\_issuer](#input\_certificate\_issuer) | YAML spec for certificate issuer; defaults to self-signed | `string` | `null` | no |
@@ -159,4 +160,5 @@ data "aws_eks_cluster" "this" {
 | <a name="input_secret_store_driver_version"></a> [secret\_store\_driver\_version](#input\_secret\_store\_driver\_version) | Version of the secret store driver to install | `string` | `null` | no |
 | <a name="input_secret_store_provider_values"></a> [secret\_store\_provider\_values](#input\_secret\_store\_provider\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_vertical_pod_autoscaler_values"></a> [vertical\_pod\_autoscaler\_values](#input\_vertical\_pod\_autoscaler\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
+| <a name="input_workspace_region"></a> [workspace\_region](#input\_workspace\_region) | Region of the Prometheus workspace for centralized ingestion | `string` | `"us-east-1"` | no |
 <!-- END_TF_DOCS -->

--- a/aws/platform/README.md
+++ b/aws/platform/README.md
@@ -112,7 +112,6 @@ data "aws_eks_cluster" "this" {
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_route53_zone.managed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
-| [aws_s3_bucket_object.prometheus](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket_object) | data source |
 | [aws_ssm_parameter.node_role_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.oidc_issuer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.pagerduty_routing_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
@@ -125,7 +124,6 @@ data "aws_eks_cluster" "this" {
 | <a name="input_aws_load_balancer_controller_values"></a> [aws\_load\_balancer\_controller\_values](#input\_aws\_load\_balancer\_controller\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_aws_load_balancer_controller_version"></a> [aws\_load\_balancer\_controller\_version](#input\_aws\_load\_balancer\_controller\_version) | Version of aws-load-balancer-controller to install | `string` | `null` | no |
 | <a name="input_aws_namespace"></a> [aws\_namespace](#input\_aws\_namespace) | Prefix to be applied to created AWS resources | `list(string)` | `[]` | no |
-| <a name="input_aws_prometheus_workspace_id"></a> [aws\_prometheus\_workspace\_id](#input\_aws\_prometheus\_workspace\_id) | Id for the prometheus workspace created in AWS | `string` | `null` | no |
 | <a name="input_aws_tags"></a> [aws\_tags](#input\_aws\_tags) | Tags to be applied to created AWS resources | `map(string)` | `{}` | no |
 | <a name="input_cert_manager_values"></a> [cert\_manager\_values](#input\_cert\_manager\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_certificate_issuer"></a> [certificate\_issuer](#input\_certificate\_issuer) | YAML spec for certificate issuer; defaults to self-signed | `string` | `null` | no |
@@ -152,13 +150,12 @@ data "aws_eks_cluster" "this" {
 | <a name="input_node_roles"></a> [node\_roles](#input\_node\_roles) | Additional node roles which can join the cluster | `list(string)` | `[]` | no |
 | <a name="input_pagerduty_parameter"></a> [pagerduty\_parameter](#input\_pagerduty\_parameter) | SSM parameter containing the Pagerduty routing key | `string` | `null` | no |
 | <a name="input_prometheus_adapter_values"></a> [prometheus\_adapter\_values](#input\_prometheus\_adapter\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
+| <a name="input_prometheus_data_source"></a> [prometheus\_data\_source](#input\_prometheus\_data\_source) | Prometheus datasource object with necessary details required to connect to the Prometheus workspace for centralized ingestion | <pre>object({<br>    # The name of the Prometheus workspace for centralized injestion<br>    name = string<br><br>    # The Prometheus workspace host. <br>    # A sample value for AWs managed Prometheus will be `aps-workspaces.us-east-1.amazonaws.com`<br>    host = string<br><br>    # The Prometheus workspace query path. <br>    # A sample value for AWs managed Prometheus will be `workspaces/ws-xxxxx-xxx-xxx-xxx-xxxxxxx/api/v1/query`<br>    query_path = string<br><br>    # The region for the Prometheus workspace created for centralized injestion path.<br>    region = string<br><br>    # The ARN of the AWS IAM role enabling this cluster to use the Prometheus workspace for centralized ingestion <br>    role_arn = string<br><br>    # The write path for the Prometheus workspace. <br>    # A sample value for AWs managed Prometheus will be `workspaces/ws-xxxxx-xxx-xxx-xxx-xxxxxxx/api/v1/remote_write`<br>    write_path = string<br>  })</pre> | <pre>{<br>  "host": null,<br>  "name": null,<br>  "query_path": null,<br>  "region": null,<br>  "role_arn": null,<br>  "write_path": null<br>}</pre> | no |
 | <a name="input_prometheus_operator_values"></a> [prometheus\_operator\_values](#input\_prometheus\_operator\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
-| <a name="input_prometheus_workspace_name"></a> [prometheus\_workspace\_name](#input\_prometheus\_workspace\_name) | Name of the Prometheus workspace for centralized ingestion | `string` | `null` | no |
 | <a name="input_reloader_values"></a> [reloader\_values](#input\_reloader\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_reloader_version"></a> [reloader\_version](#input\_reloader\_version) | Version of external-dns to install | `string` | `null` | no |
 | <a name="input_secret_store_driver_values"></a> [secret\_store\_driver\_values](#input\_secret\_store\_driver\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_secret_store_driver_version"></a> [secret\_store\_driver\_version](#input\_secret\_store\_driver\_version) | Version of the secret store driver to install | `string` | `null` | no |
 | <a name="input_secret_store_provider_values"></a> [secret\_store\_provider\_values](#input\_secret\_store\_provider\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_vertical_pod_autoscaler_values"></a> [vertical\_pod\_autoscaler\_values](#input\_vertical\_pod\_autoscaler\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
-| <a name="input_workspace_region"></a> [workspace\_region](#input\_workspace\_region) | Region of the Prometheus workspace for centralized ingestion | `string` | `"us-east-1"` | no |
 <!-- END_TF_DOCS -->

--- a/aws/platform/main.tf
+++ b/aws/platform/main.tf
@@ -155,7 +155,7 @@ data "aws_route53_zone" "managed" {
 }
 
 data "aws_s3_bucket_object" "prometheus" {
-  count = var.prometheus_workspace_name == null ? 0 : 1
+  count = var.aws_prometheus_workspace_id != "" ? 0 : (var.prometheus_workspace_name == null ? 0 : 1)
 
   bucket = join("-", concat([
     "prometheus",
@@ -409,7 +409,24 @@ locals {
     ]
   )
 
-  prometheus_workspace = try(jsondecode(local.prometheus_workspace_json), {})
+  prometheus_workspace = local.prometheus_workspace_s3 == {} ? local.prometheus_data_source : local.prometheus_workspace_s3
 
-  prometheus_workspace_json = join("", data.aws_s3_bucket_object.prometheus.*.body)
+  prometheus_workspace_s3 = try(jsondecode(local.prometheus_workspace_json), {})
+
+  prometheus_workspace_json = try(join("", data.aws_s3_bucket_object.prometheus.*.body), {})
+
+  workspace_host = "aps-workspaces.${var.workspace_region}.amazonaws.com"
+
+  workspace_path = "workspaces/${var.aws_prometheus_workspace_id}"
+
+  injestion_role_name = var.prometheus_workspace_name == null ? "" : join("-", concat([var.prometheus_workspace_name, "prometheus", "ingestion"]))
+
+  prometheus_data_source = {
+    host       = local.workspace_host
+    query_path = "${local.workspace_path}/api/v1/query"
+    region     = var.workspace_region
+    role_arn   = "arn:aws:iam::${local.monitoring_account_id}:role/${local.injestion_role_name}"
+    write_path = "${local.workspace_path}/api/v1/remote_write"
+    url        = "https://${local.workspace_host}/${local.workspace_path}/"
+  }
 }

--- a/aws/platform/main.tf
+++ b/aws/platform/main.tf
@@ -131,7 +131,7 @@ module "cluster_autoscaler_service_account_role" {
 }
 
 module "prometheus_service_account_role" {
-  count  = var.prometheus_workspace_name == null ? 0 : 1
+  count  = var.prometheus_data_source["name"] == null ? 0 : 1
   source = "./modules/prometheus-service-account-role"
 
   aws_namespace        = [module.cluster_name.full]
@@ -139,7 +139,7 @@ module "prometheus_service_account_role" {
   k8s_namespace        = "kube-prometheus-stack"
   oidc_issuer          = data.aws_ssm_parameter.oidc_issuer.value
   workspace_account_id = local.monitoring_account_id
-  workspace_name       = var.prometheus_workspace_name
+  workspace_name       = var.prometheus_data_source["name"]
 }
 
 module "secrets_store_provider" {
@@ -152,18 +152,6 @@ data "aws_route53_zone" "managed" {
   for_each = toset(var.hosted_zones)
 
   name = each.value
-}
-
-data "aws_s3_bucket_object" "prometheus" {
-  count = var.aws_prometheus_workspace_id != "" ? 0 : (var.prometheus_workspace_name == null ? 0 : 1)
-
-  bucket = join("-", concat([
-    "prometheus",
-    var.prometheus_workspace_name,
-    local.monitoring_account_id
-  ]))
-
-  key = "ingestion.json"
 }
 
 data "aws_ssm_parameter" "node_role_arn" {
@@ -241,7 +229,7 @@ locals {
 
   federated_prometheus_values = concat(
     (
-      var.prometheus_workspace_name == null ?
+      var.prometheus_data_source["host"] == null ?
       [] :
       [
         yamlencode({
@@ -260,13 +248,13 @@ locals {
                     "--name",
                     "aps",
                     "--region",
-                    local.prometheus_workspace["region"],
+                    var.prometheus_data_source["region"],
                     "--host",
-                    local.prometheus_workspace["host"],
+                    var.prometheus_data_source["host"],
                     "--port",
                     ":8005",
                     "--role-arn",
-                    local.prometheus_workspace["role_arn"]
+                    var.prometheus_data_source["role_arn"]
                   ]
                   name  = "sigv4-proxy"
                   image = "public.ecr.aws/aws-observability/aws-sigv4-proxy:1.0"
@@ -285,7 +273,7 @@ locals {
                     maxSamplesPerSend = 1000
                     maxShards         = 200
                   }
-                  url = "http://localhost:8005/${local.prometheus_workspace["write_path"]}"
+                  url = "http://localhost:8005/${var.prometheus_data_source["write_path"]}"
                 }
               ]
             }
@@ -408,25 +396,4 @@ locals {
       })
     ]
   )
-
-  prometheus_workspace = local.prometheus_workspace_s3 == {} ? local.prometheus_data_source : local.prometheus_workspace_s3
-
-  prometheus_workspace_s3 = try(jsondecode(local.prometheus_workspace_json), {})
-
-  prometheus_workspace_json = try(join("", data.aws_s3_bucket_object.prometheus.*.body), {})
-
-  workspace_host = "aps-workspaces.${var.workspace_region}.amazonaws.com"
-
-  workspace_path = "workspaces/${var.aws_prometheus_workspace_id}"
-
-  injestion_role_name = var.prometheus_workspace_name == null ? "" : join("-", concat([var.prometheus_workspace_name, "prometheus", "ingestion"]))
-
-  prometheus_data_source = {
-    host       = local.workspace_host
-    query_path = "${local.workspace_path}/api/v1/query"
-    region     = var.workspace_region
-    role_arn   = "arn:aws:iam::${local.monitoring_account_id}:role/${local.injestion_role_name}"
-    write_path = "${local.workspace_path}/api/v1/remote_write"
-    url        = "https://${local.workspace_host}/${local.workspace_path}/"
-  }
 }

--- a/aws/platform/variables.tf
+++ b/aws/platform/variables.tf
@@ -22,6 +22,12 @@ variable "aws_namespace" {
   description = "Prefix to be applied to created AWS resources"
 }
 
+variable "aws_prometheus_workspace_id" {
+  description = "Id for the prometheus workspace created in AWS. This variable is mandatory if the Prometheus workspace for centralized ingestion is in a different region"
+  type        = string
+  default     = ""
+}
+
 variable "aws_tags" {
   type        = map(string)
   description = "Tags to be applied to created AWS resources"
@@ -223,4 +229,10 @@ variable "vertical_pod_autoscaler_values" {
   description = "Overrides to pass to the Helm chart"
   type        = list(string)
   default     = []
+}
+
+variable "workspace_region" {
+  description = "Region of the Prometheus workspace for centralized ingestion. This variable is mandatory if the Prometheus workspace for centralized ingestion is in a different region"
+  type        = string
+  default     = "us-east-1"
 }

--- a/aws/platform/variables.tf
+++ b/aws/platform/variables.tf
@@ -22,12 +22,6 @@ variable "aws_namespace" {
   description = "Prefix to be applied to created AWS resources"
 }
 
-variable "aws_prometheus_workspace_id" {
-  description = "Id for the prometheus workspace created in AWS. This variable is mandatory if the Prometheus workspace for centralized ingestion is in a different region"
-  type        = string
-  default     = ""
-}
-
 variable "aws_tags" {
   type        = map(string)
   description = "Tags to be applied to created AWS resources"
@@ -189,10 +183,38 @@ variable "monitoring_account_id" {
   default     = null
 }
 
-variable "prometheus_workspace_name" {
-  description = "Name of the Prometheus workspace for centralized ingestion"
-  type        = string
-  default     = null
+variable "prometheus_data_source" {
+  description = "Prometheus datasource object with necessary details required to connect to the Prometheus workspace for centralized ingestion"
+  type = object({
+    # The name of the Prometheus workspace for centralized injestion
+    name = string
+
+    # The Prometheus workspace host. 
+    # A sample value for AWs managed Prometheus will be `aps-workspaces.us-east-1.amazonaws.com`
+    host = string
+
+    # The Prometheus workspace query path. 
+    # A sample value for AWs managed Prometheus will be `workspaces/ws-xxxxx-xxx-xxx-xxx-xxxxxxx/api/v1/query`
+    query_path = string
+
+    # The region for the Prometheus workspace created for centralized injestion path.
+    region = string
+
+    # The ARN of the AWS IAM role enabling this cluster to use the Prometheus workspace for centralized ingestion 
+    role_arn = string
+
+    # The write path for the Prometheus workspace. 
+    # A sample value for AWs managed Prometheus will be `workspaces/ws-xxxxx-xxx-xxx-xxx-xxxxxxx/api/v1/remote_write`
+    write_path = string
+  })
+  default = {
+    name       = null
+    host       = null
+    query_path = null
+    region     = null
+    role_arn   = null
+    write_path = null
+  }
 }
 
 variable "reloader_values" {
@@ -229,10 +251,4 @@ variable "vertical_pod_autoscaler_values" {
   description = "Overrides to pass to the Helm chart"
   type        = list(string)
   default     = []
-}
-
-variable "workspace_region" {
-  description = "Region of the Prometheus workspace for centralized ingestion. This variable is mandatory if the Prometheus workspace for centralized ingestion is in a different region"
-  type        = string
-  default     = "us-east-1"
 }

--- a/aws/prometheus-workspace/README.md
+++ b/aws/prometheus-workspace/README.md
@@ -19,6 +19,10 @@ write to the workspace.
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
 
+## Modules
+
+No modules.
+
 ## Resources
 
 | Name | Type |
@@ -44,4 +48,10 @@ write to the workspace.
 | <a name="input_name"></a> [name](#input\_name) | Name for this Prometheus workspace | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to created resources | `map(string)` | `{}` | no |
 | <a name="input_workload_account_ids"></a> [workload\_account\_ids](#input\_workload\_account\_ids) | Workload accounts allowed to write to this workspace | `list(string)` | `[]` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_aws_prometheus_workspace_id"></a> [aws\_prometheus\_workspace\_id](#output\_aws\_prometheus\_workspace\_id) | Id for the prometheus workspace created in AWS |
 <!-- END_TF_DOCS -->

--- a/aws/prometheus-workspace/README.md
+++ b/aws/prometheus-workspace/README.md
@@ -19,10 +19,6 @@ write to the workspace.
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
 
-## Modules
-
-No modules.
-
 ## Resources
 
 | Name | Type |
@@ -53,5 +49,6 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_aws_prometheus_workspace_endpoint"></a> [aws\_prometheus\_workspace\_endpoint](#output\_aws\_prometheus\_workspace\_endpoint) | Prometheus endpoint available for this workspace |
 | <a name="output_aws_prometheus_workspace_id"></a> [aws\_prometheus\_workspace\_id](#output\_aws\_prometheus\_workspace\_id) | Id for the prometheus workspace created in AWS |
 <!-- END_TF_DOCS -->

--- a/aws/prometheus-workspace/outputs.tf
+++ b/aws/prometheus-workspace/outputs.tf
@@ -1,1 +1,4 @@
-
+output "aws_prometheus_workspace_id" {
+  description = "Id for the prometheus workspace created in AWS"
+  value       = aws_prometheus_workspace.this.id
+}

--- a/aws/prometheus-workspace/outputs.tf
+++ b/aws/prometheus-workspace/outputs.tf
@@ -1,3 +1,8 @@
+output "aws_prometheus_workspace_endpoint" {
+  description = "Prometheus endpoint available for this workspace"
+  value       = aws_prometheus_workspace.this.prometheus_endpoint
+}
+
 output "aws_prometheus_workspace_id" {
   description = "Id for the prometheus workspace created in AWS"
   value       = aws_prometheus_workspace.this.id


### PR DESCRIPTION
This update enables EKS clusters in regions other than the region for the centralised prometheus workspace to write remotely to the prometheus workspace.  

Previously, the module needed to retrieve the prometheus data-source details in an `ingestion.json` file kept in a bucket within the same region (for example `us-east-1`) as the centralised prometheus workspace. So if the EKS cluster trying to write to this workspace is not in the same region as the centralised prometheus workspace (`us-east-1` in this case), the bucket will not be found. 

With this update, the prometheus datasource details will be built within the module and the necessary information to achieve this are now being passed in to the module as variables.