### PR TITLE
Add opsgenie api key to latest version

### DIFF
--- a/aws/platform/main.tf
+++ b/aws/platform/main.tf
@@ -11,6 +11,7 @@ module "common_platform" {
   metrics_server_values                    = var.metrics_server_values
   metrics_server_version                   = var.metrics_server_version
   pagerduty_routing_key                    = local.pagerduty_routing_key
+  opsgenie_api_key                         = local.opsgenie_api_key
   prometheus_adapter_values                = var.prometheus_adapter_values
   reloader_values                          = var.reloader_values
   reloader_version                         = var.reloader_version
@@ -184,6 +185,12 @@ data "aws_ssm_parameter" "pagerduty_routing_key" {
   count = var.pagerduty_parameter == null ? 0 : 1
 
   name = var.pagerduty_parameter
+}
+
+data "aws_ssm_parameter" "opsgenie_api_key" {
+  count = var.opsgenie_parameter == null ? 0 : 1
+
+  name = var.opsgenie_parameter
 }
 
 data "aws_caller_identity" "this" {}
@@ -383,6 +390,12 @@ locals {
     var.pagerduty_parameter == null ?
     null :
     join("", data.aws_ssm_parameter.pagerduty_routing_key.*.value)
+  )
+
+  opsgenie_api_key = (
+    var.opsgenie_parameter == null ?
+    null :
+    join("", data.aws_ssm_parameter.opsgenie_api_key.*.value)
   )
 
   prometheus_operator_values = concat(

--- a/aws/platform/variables.tf
+++ b/aws/platform/variables.tf
@@ -164,6 +164,12 @@ variable "pagerduty_parameter" {
   default     = null
 }
 
+variable "opsgenie_parameter" {
+  type        = string
+  description = "SSM parameter containing the OpsGenie api key"
+  default     = null
+}
+
 variable "prometheus_adapter_values" {
   description = "Overrides to pass to the Helm chart"
   type        = list(string)

--- a/platform/README.md
+++ b/platform/README.md
@@ -91,6 +91,7 @@ practices.
 | <a name="input_istiod_values"></a> [istiod\_values](#input\_istiod\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_metrics_server_values"></a> [metrics\_server\_values](#input\_metrics\_server\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_metrics_server_version"></a> [metrics\_server\_version](#input\_metrics\_server\_version) | Version of the Metrics Server to install | `string` | `null` | no |
+| <a name="input_opsgenie_api_key"></a> [opsgenie\_api\_key](#input\_opsgenie\_api\_key) | API key for delivering OpsGenie alerts | `string` | `null` | no |
 | <a name="input_pagerduty_routing_key"></a> [pagerduty\_routing\_key](#input\_pagerduty\_routing\_key) | Routing key for delivering Pagerduty alerts | `string` | `null` | no |
 | <a name="input_prometheus_adapter_values"></a> [prometheus\_adapter\_values](#input\_prometheus\_adapter\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_prometheus_adapter_version"></a> [prometheus\_adapter\_version](#input\_prometheus\_adapter\_version) | Version of prometheus adapter to install | `string` | `null` | no |

--- a/platform/main.tf
+++ b/platform/main.tf
@@ -111,6 +111,7 @@ module "prometheus_operator" {
   chart_version         = var.prometheus_operator_version
   k8s_namespace         = local.kube_prometheus_stack_namespace
   pagerduty_routing_key = var.pagerduty_routing_key
+  opsgenie_api_key      = var.opsgenie_api_key
 
   depends_on = [module.cert_manager, module.vertical_pod_autoscaler]
 }

--- a/platform/modules/prometheus-operator/variables.tf
+++ b/platform/modules/prometheus-operator/variables.tf
@@ -38,3 +38,9 @@ variable "pagerduty_routing_key" {
   description = "Routing key for delivering Pagerduty alerts"
   default     = null
 }
+
+variable "opsgenie_api_key" {
+  type        = string
+  description = "API key for delivering OpsGenie alerts"
+  default     = null
+}

--- a/platform/variables.tf
+++ b/platform/variables.tf
@@ -142,6 +142,12 @@ variable "pagerduty_routing_key" {
   default     = null
 }
 
+variable "opsgenie_api_key" {
+  type        = string
+  description = "API key for delivering OpsGenie alerts"
+  default     = null
+}
+
 variable "prometheus_adapter_values" {
   description = "Overrides to pass to the Helm chart"
   type        = list(string)


### PR DESCRIPTION
This is the work done for the latest version, it's not currently in use because the brm v2 clusters were based off of v0.5, and there was some reorganization done that made it easier to redo the work on the previous version.