### PR TITLE
Pass prometheus workspace datasource into platform module

### DIFF
--- a/aws/prometheus-workspace/README.md
+++ b/aws/prometheus-workspace/README.md
@@ -51,5 +51,7 @@ No modules.
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_aws_prometheus_workspace_id"></a> [aws\_prometheus\_workspace\_id](#output\_aws\_prometheus\_workspace\_id) | Id for the prometheus workspace created in AWS |
 <!-- END_TF_DOCS -->

--- a/aws/prometheus-workspace/README.md
+++ b/aws/prometheus-workspace/README.md
@@ -19,10 +19,6 @@ write to the workspace.
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
 
-## Modules
-
-No modules.
-
 ## Resources
 
 | Name | Type |
@@ -53,5 +49,6 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_aws_prometheus_workspace_endpoint"></a> [aws\_prometheus\_workspace\_endpoint](#output\_aws\_prometheus\_workspace\_endpoint) | Prometheus endpoint available for this workspace |
 | <a name="output_aws_prometheus_workspace_id"></a> [aws\_prometheus\_workspace\_id](#output\_aws\_prometheus\_workspace\_id) | Id for the prometheus workspace created in AWS |
 <!-- END_TF_DOCS -->

--- a/aws/prometheus-workspace/outputs.tf
+++ b/aws/prometheus-workspace/outputs.tf
@@ -1,1 +1,4 @@
-
+output "aws_prometheus_workspace_id" {
+  description = "Id for the prometheus workspace created in AWS"
+  value       = aws_prometheus_workspace.this.id
+}

--- a/aws/prometheus-workspace/outputs.tf
+++ b/aws/prometheus-workspace/outputs.tf
@@ -1,3 +1,8 @@
+output "aws_prometheus_workspace_endpoint" {
+  description = "Prometheus endpoint available for this workspace"
+  value       = aws_prometheus_workspace.this.prometheus_endpoint
+}
+
 output "aws_prometheus_workspace_id" {
   description = "Id for the prometheus workspace created in AWS"
   value       = aws_prometheus_workspace.this.id

--- a/aws/workload-platform/README.md
+++ b/aws/workload-platform/README.md
@@ -19,22 +19,22 @@ Cluster Autoscaler, and ExternalDNS.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.75.1 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_auth_config_map"></a> [auth\_config\_map](#module\_auth\_config\_map) | ../auth-config-map |  |
-| <a name="module_aws_load_balancer_controller"></a> [aws\_load\_balancer\_controller](#module\_aws\_load\_balancer\_controller) | ../load-balancer-controller |  |
-| <a name="module_cloudwatch_logs"></a> [cloudwatch\_logs](#module\_cloudwatch\_logs) | ../cloudwatch-logs |  |
-| <a name="module_cluster_autoscaler_service_account_role"></a> [cluster\_autoscaler\_service\_account\_role](#module\_cluster\_autoscaler\_service\_account\_role) | ../cluster-autoscaler-service-account-role |  |
-| <a name="module_cluster_name"></a> [cluster\_name](#module\_cluster\_name) | ../cluster-name |  |
-| <a name="module_common_platform"></a> [common\_platform](#module\_common\_platform) | ../../common/workload-platform |  |
-| <a name="module_dns_service_account_role"></a> [dns\_service\_account\_role](#module\_dns\_service\_account\_role) | ../dns-service-account-role |  |
-| <a name="module_network"></a> [network](#module\_network) | ../network-data |  |
-| <a name="module_prometheus_service_account_role"></a> [prometheus\_service\_account\_role](#module\_prometheus\_service\_account\_role) | ../prometheus-service-account-role |  |
-| <a name="module_secrets_store_provider"></a> [secrets\_store\_provider](#module\_secrets\_store\_provider) | ../secrets-store-provider |  |
+| <a name="module_auth_config_map"></a> [auth\_config\_map](#module\_auth\_config\_map) | ../auth-config-map | n/a |
+| <a name="module_aws_load_balancer_controller"></a> [aws\_load\_balancer\_controller](#module\_aws\_load\_balancer\_controller) | ../load-balancer-controller | n/a |
+| <a name="module_cloudwatch_logs"></a> [cloudwatch\_logs](#module\_cloudwatch\_logs) | ../cloudwatch-logs | n/a |
+| <a name="module_cluster_autoscaler_service_account_role"></a> [cluster\_autoscaler\_service\_account\_role](#module\_cluster\_autoscaler\_service\_account\_role) | ../cluster-autoscaler-service-account-role | n/a |
+| <a name="module_cluster_name"></a> [cluster\_name](#module\_cluster\_name) | ../cluster-name | n/a |
+| <a name="module_common_platform"></a> [common\_platform](#module\_common\_platform) | ../../common/workload-platform | n/a |
+| <a name="module_dns_service_account_role"></a> [dns\_service\_account\_role](#module\_dns\_service\_account\_role) | ../dns-service-account-role | n/a |
+| <a name="module_network"></a> [network](#module\_network) | ../network-data | n/a |
+| <a name="module_prometheus_service_account_role"></a> [prometheus\_service\_account\_role](#module\_prometheus\_service\_account\_role) | ../prometheus-service-account-role | n/a |
+| <a name="module_secrets_store_provider"></a> [secrets\_store\_provider](#module\_secrets\_store\_provider) | ../secrets-store-provider | n/a |
 
 ## Resources
 
@@ -88,4 +88,8 @@ Cluster Autoscaler, and ExternalDNS.
 | <a name="input_secret_store_driver_version"></a> [secret\_store\_driver\_version](#input\_secret\_store\_driver\_version) | Version of the secret store driver to install | `string` | `null` | no |
 | <a name="input_secret_store_provider_values"></a> [secret\_store\_provider\_values](#input\_secret\_store\_provider\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_vertical_pod_autoscaler_values"></a> [vertical\_pod\_autoscaler\_values](#input\_vertical\_pod\_autoscaler\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
+
+## Outputs
+
+No outputs.
 <!-- END_TF_DOCS -->

--- a/aws/workload-platform/README.md
+++ b/aws/workload-platform/README.md
@@ -43,7 +43,6 @@ Cluster Autoscaler, and ExternalDNS.
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_route53_zone.managed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
-| [aws_s3_bucket_object.prometheus](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket_object) | data source |
 | [aws_ssm_parameter.node_role_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.oidc_issuer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.pagerduty_routing_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
@@ -56,7 +55,6 @@ Cluster Autoscaler, and ExternalDNS.
 | <a name="input_aws_load_balancer_controller_values"></a> [aws\_load\_balancer\_controller\_values](#input\_aws\_load\_balancer\_controller\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_aws_load_balancer_controller_version"></a> [aws\_load\_balancer\_controller\_version](#input\_aws\_load\_balancer\_controller\_version) | Version of aws-load-balancer-controller to install | `string` | `null` | no |
 | <a name="input_aws_namespace"></a> [aws\_namespace](#input\_aws\_namespace) | Prefix to be applied to created AWS resources | `list(string)` | `[]` | no |
-| <a name="input_aws_prometheus_workspace_id"></a> [aws\_prometheus\_workspace\_id](#input\_aws\_prometheus\_workspace\_id) | Id for the prometheus workspace created in AWS | `string` | `null` | no |
 | <a name="input_aws_tags"></a> [aws\_tags](#input\_aws\_tags) | Tags to be applied to created AWS resources | `map(string)` | `{}` | no |
 | <a name="input_cert_manager_values"></a> [cert\_manager\_values](#input\_cert\_manager\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_certificate_issuer"></a> [certificate\_issuer](#input\_certificate\_issuer) | YAML spec for certificate issuer; defaults to self-signed | `string` | `null` | no |
@@ -82,13 +80,12 @@ Cluster Autoscaler, and ExternalDNS.
 | <a name="input_node_roles"></a> [node\_roles](#input\_node\_roles) | Additional node roles which can join the cluster | `list(string)` | `[]` | no |
 | <a name="input_pagerduty_parameter"></a> [pagerduty\_parameter](#input\_pagerduty\_parameter) | SSM parameter containing the Pagerduty routing key | `string` | `null` | no |
 | <a name="input_prometheus_adapter_values"></a> [prometheus\_adapter\_values](#input\_prometheus\_adapter\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
+| <a name="input_prometheus_data_source"></a> [prometheus\_data\_source](#input\_prometheus\_data\_source) | Prometheus datasource object with necessary details required to connect to the Prometheus workspace for centralized ingestion | <pre>object({<br>    # The name of the Prometheus workspace for centralized injestion<br>    name = string<br><br>    # The Prometheus workspace host. <br>    # A sample value for AWs managed Prometheus will be `aps-workspaces.us-east-1.amazonaws.com`<br>    host = string<br><br>    # The Prometheus workspace query path. <br>    # A sample value for AWs managed Prometheus will be `workspaces/ws-xxxxx-xxx-xxx-xxx-xxxxxxx/api/v1/query`<br>    query_path = string<br><br>    # The region for the Prometheus workspace created for centralized injestion path.<br>    region = string<br><br>    # The ARN of the AWS IAM role enabling this cluster to use the Prometheus workspace for centralized ingestion <br>    role_arn = string<br><br>    # The write path for the Prometheus workspace. <br>    # A sample value for AWs managed Prometheus will be `workspaces/ws-xxxxx-xxx-xxx-xxx-xxxxxxx/api/v1/remote_write`<br>    write_path = string<br>  })</pre> | <pre>{<br>  "host": null,<br>  "name": null,<br>  "query_path": null,<br>  "region": null,<br>  "role_arn": null,<br>  "write_path": null<br>}</pre> | no |
 | <a name="input_prometheus_operator_values"></a> [prometheus\_operator\_values](#input\_prometheus\_operator\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
-| <a name="input_prometheus_workspace_name"></a> [prometheus\_workspace\_name](#input\_prometheus\_workspace\_name) | Name of the Prometheus workspace for centralized ingestion | `string` | `null` | no |
 | <a name="input_reloader_values"></a> [reloader\_values](#input\_reloader\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_reloader_version"></a> [reloader\_version](#input\_reloader\_version) | Version of external-dns to install | `string` | `null` | no |
 | <a name="input_secret_store_driver_values"></a> [secret\_store\_driver\_values](#input\_secret\_store\_driver\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_secret_store_driver_version"></a> [secret\_store\_driver\_version](#input\_secret\_store\_driver\_version) | Version of the secret store driver to install | `string` | `null` | no |
 | <a name="input_secret_store_provider_values"></a> [secret\_store\_provider\_values](#input\_secret\_store\_provider\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_vertical_pod_autoscaler_values"></a> [vertical\_pod\_autoscaler\_values](#input\_vertical\_pod\_autoscaler\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
-| <a name="input_workspace_region"></a> [workspace\_region](#input\_workspace\_region) | Region of the Prometheus workspace for centralized ingestion | `string` | `"us-east-1"` | no |
 <!-- END_TF_DOCS -->

--- a/aws/workload-platform/README.md
+++ b/aws/workload-platform/README.md
@@ -56,6 +56,7 @@ Cluster Autoscaler, and ExternalDNS.
 | <a name="input_aws_load_balancer_controller_values"></a> [aws\_load\_balancer\_controller\_values](#input\_aws\_load\_balancer\_controller\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_aws_load_balancer_controller_version"></a> [aws\_load\_balancer\_controller\_version](#input\_aws\_load\_balancer\_controller\_version) | Version of aws-load-balancer-controller to install | `string` | `null` | no |
 | <a name="input_aws_namespace"></a> [aws\_namespace](#input\_aws\_namespace) | Prefix to be applied to created AWS resources | `list(string)` | `[]` | no |
+| <a name="input_aws_prometheus_workspace_id"></a> [aws\_prometheus\_workspace\_id](#input\_aws\_prometheus\_workspace\_id) | Id for the prometheus workspace created in AWS | `string` | `null` | no |
 | <a name="input_aws_tags"></a> [aws\_tags](#input\_aws\_tags) | Tags to be applied to created AWS resources | `map(string)` | `{}` | no |
 | <a name="input_cert_manager_values"></a> [cert\_manager\_values](#input\_cert\_manager\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_certificate_issuer"></a> [certificate\_issuer](#input\_certificate\_issuer) | YAML spec for certificate issuer; defaults to self-signed | `string` | `null` | no |
@@ -89,8 +90,5 @@ Cluster Autoscaler, and ExternalDNS.
 | <a name="input_secret_store_driver_version"></a> [secret\_store\_driver\_version](#input\_secret\_store\_driver\_version) | Version of the secret store driver to install | `string` | `null` | no |
 | <a name="input_secret_store_provider_values"></a> [secret\_store\_provider\_values](#input\_secret\_store\_provider\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_vertical_pod_autoscaler_values"></a> [vertical\_pod\_autoscaler\_values](#input\_vertical\_pod\_autoscaler\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
-
-## Outputs
-
-No outputs.
+| <a name="input_workspace_region"></a> [workspace\_region](#input\_workspace\_region) | Region of the Prometheus workspace for centralized ingestion | `string` | `"us-east-1"` | no |
 <!-- END_TF_DOCS -->

--- a/aws/workload-platform/main.tf
+++ b/aws/workload-platform/main.tf
@@ -131,7 +131,7 @@ module "cluster_autoscaler_service_account_role" {
 
 module "prometheus_service_account_role" {
   count  = var.prometheus_data_source["name"] == null ? 0 : 1
-  source = "./modules/prometheus-service-account-role"
+  source = "../prometheus-service-account-role"
 
   aws_namespace        = [module.cluster_name.full]
   aws_tags             = var.aws_tags

--- a/aws/workload-platform/variables.tf
+++ b/aws/workload-platform/variables.tf
@@ -22,6 +22,12 @@ variable "aws_namespace" {
   description = "Prefix to be applied to created AWS resources"
 }
 
+variable "aws_prometheus_workspace_id" {
+  description = "Id for the prometheus workspace created in AWS. This variable is mandatory if the Prometheus workspace for centralized ingestion is in a different region"
+  type        = string
+  default     = ""
+}
+
 variable "aws_tags" {
   type        = map(string)
   description = "Tags to be applied to created AWS resources"
@@ -217,4 +223,10 @@ variable "vertical_pod_autoscaler_values" {
   description = "Overrides to pass to the Helm chart"
   type        = list(string)
   default     = []
+}
+
+variable "workspace_region" {
+  description = "Region of the Prometheus workspace for centralized ingestion. This variable is mandatory if the Prometheus workspace for centralized ingestion is in a different region"
+  type        = string
+  default     = "us-east-1"
 }

--- a/aws/workload-platform/variables.tf
+++ b/aws/workload-platform/variables.tf
@@ -22,12 +22,6 @@ variable "aws_namespace" {
   description = "Prefix to be applied to created AWS resources"
 }
 
-variable "aws_prometheus_workspace_id" {
-  description = "Id for the prometheus workspace created in AWS. This variable is mandatory if the Prometheus workspace for centralized ingestion is in a different region"
-  type        = string
-  default     = ""
-}
-
 variable "aws_tags" {
   type        = map(string)
   description = "Tags to be applied to created AWS resources"
@@ -183,10 +177,38 @@ variable "monitoring_account_id" {
   default     = null
 }
 
-variable "prometheus_workspace_name" {
-  description = "Name of the Prometheus workspace for centralized ingestion"
-  type        = string
-  default     = null
+variable "prometheus_data_source" {
+  description = "Prometheus datasource object with necessary details required to connect to the Prometheus workspace for centralized ingestion"
+  type = object({
+    # The name of the Prometheus workspace for centralized injestion
+    name = string
+
+    # The Prometheus workspace host. 
+    # A sample value for AWs managed Prometheus will be `aps-workspaces.us-east-1.amazonaws.com`
+    host = string
+
+    # The Prometheus workspace query path. 
+    # A sample value for AWs managed Prometheus will be `workspaces/ws-xxxxx-xxx-xxx-xxx-xxxxxxx/api/v1/query`
+    query_path = string
+
+    # The region for the Prometheus workspace created for centralized injestion path.
+    region = string
+
+    # The ARN of the AWS IAM role enabling this cluster to use the Prometheus workspace for centralized ingestion 
+    role_arn = string
+
+    # The write path for the Prometheus workspace. 
+    # A sample value for AWs managed Prometheus will be `workspaces/ws-xxxxx-xxx-xxx-xxx-xxxxxxx/api/v1/remote_write`
+    write_path = string
+  })
+  default = {
+    name       = null
+    host       = null
+    query_path = null
+    region     = null
+    role_arn   = null
+    write_path = null
+  }
 }
 
 variable "reloader_values" {
@@ -223,10 +245,4 @@ variable "vertical_pod_autoscaler_values" {
   description = "Overrides to pass to the Helm chart"
   type        = list(string)
   default     = []
-}
-
-variable "workspace_region" {
-  description = "Region of the Prometheus workspace for centralized ingestion. This variable is mandatory if the Prometheus workspace for centralized ingestion is in a different region"
-  type        = string
-  default     = "us-east-1"
 }


### PR DESCRIPTION
This update enables EKS clusters in regions other than the region for the centralised prometheus workspace to write remotely to the prometheus workspace.