### PR TITLE
Record ratio of replicas updated

### DIFF
--- a/platform/modules/prometheus-operator/workload-rules.yaml
+++ b/platform/modules/prometheus-operator/workload-rules.yaml
@@ -10,3 +10,9 @@ groups:
         kube_horizontalpodautoscaler_spec_max_replicas
       ) without (instance, pod)
     record: hpa:replica_ratio:mean
+  - expr: |
+      avg(
+        kube_deployment_status_replicas_updated /
+        kube_deployment_status_replicas
+      ) without (instance, pod)
+    record: deploy:replicas_updated_ratio:mean


### PR DESCRIPTION
This introduces a new recorded rule in Prometheus which tracks the ratio of updated replicas for each deployment. This number can be used to track the progress as new deployments are rolled out. The metric is also useful as an annotation query for Grafana.
