### PR TITLE
Create a prometheus_data module to build a datasource object to connect to AWS prometheus workspace

### DIFF
--- a/aws/prometheus-data/README.md
+++ b/aws/prometheus-data/README.md
@@ -1,0 +1,38 @@
+# Prometheus Workspace
+
+Creates a prometheus datasource object containing the necessary details to connect to a prometheus workspace in AWS using flightdeck workload platform.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_aws_prometheus_workspace_id"></a> [aws\_prometheus\_workspace\_id](#input\_aws\_prometheus\_workspace\_id) | AWS managed prometheus workspace name. | `string` | n/a | yes |
+| <a name="input_aws_prometheus_workspace_name"></a> [aws\_prometheus\_workspace\_name](#input\_aws\_prometheus\_workspace\_name) | AWS managed prometheus workspace name | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_prometheus_data"></a> [prometheus\_data](#output\_prometheus\_data) | Prometheus datasource object for the provided workspace |
+<!-- END_TF_DOCS -->

--- a/aws/prometheus-data/main.tf
+++ b/aws/prometheus-data/main.tf
@@ -1,0 +1,14 @@
+data "aws_caller_identity" "this" {}
+
+data "aws_region" "current" {}
+
+locals {
+  prometheus_data = {
+    "host" : "aps-workspaces.${data.aws_region.current.name}.amazonaws.com",
+    "name" : var.aws_prometheus_workspace_name,
+    "query_path" : "workspaces/${var.aws_prometheus_workspace_id}/api/v1/query",
+    "region" : data.aws_region.current.name,
+    "role_arn" : "arn:aws:iam::${data.aws_caller_identity.this.account_id}:role/flightdeck-prometheus-ingestion",
+    "write_path" : "workspaces/${var.aws_prometheus_workspace_id}/api/v1/remote_write"
+  }
+}

--- a/aws/prometheus-data/makefile
+++ b/aws/prometheus-data/makefile
@@ -1,0 +1,67 @@
+MODULEFILES := $(wildcard *.tf)
+TFLINTRC    ?= ../../.tflint.hcl
+TFDOCSRC    ?= ../../.terraform-docs.yml
+
+.PHONY: default
+default: checkfmt validate docs lint
+
+.PHONY: checkfmt
+checkfmt: .fmt
+
+.PHONY: fmt
+fmt: $(MODULEFILES)
+	terraform fmt
+	@touch .fmt
+
+.PHONY: validate
+validate: .validate
+
+.PHONY: docs
+docs: README.md
+
+.PHONY: lint
+lint: .lint
+
+.lint: $(MODULEFILES) .lintinit
+	tflint --config=$(TFLINTRC)
+	@touch .lint
+
+.lintinit: $(TFLINTRC)
+	tflint --init --config=$(TFLINTRC) --module
+	@touch .lintinit
+
+README.md: $(MODULEFILES)
+	terraform-docs --config "$(TFDOCSRC)" markdown table . --output-file README.md
+
+.fmt: $(MODULEFILES)
+	terraform fmt -check
+	@touch .fmt
+
+.PHONY: init
+init: .init
+
+.init: versions.tf .dependencies
+	terraform init -backend=false
+	@touch .init
+
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
+
+.dependencies: *.tf
+	@grep -ohE \
+		"\b(backend|provider|resource|module) ['\"][[:alpha:]][[:alnum:]]*|\bsource  *=.*" *.tf | \
+		sed "s/['\"]//" | sort | uniq | \
+		tee /tmp/initdeps | \
+		diff -q .dependencies - >/dev/null 2>&1 || \
+		mv /tmp/initdeps .dependencies
+
+.PHONY: clean
+clean:
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/aws/prometheus-data/outputs.tf
+++ b/aws/prometheus-data/outputs.tf
@@ -1,0 +1,4 @@
+output "prometheus_data" {
+  description = "Prometheus datasource object for the provided workspace"
+  value       = local.prometheus_data
+}

--- a/aws/prometheus-data/variables.tf
+++ b/aws/prometheus-data/variables.tf
@@ -1,0 +1,9 @@
+variable "aws_prometheus_workspace_name" {
+  description = "AWS managed prometheus workspace name"
+  type        = string
+}
+
+variable "aws_prometheus_workspace_id" {
+  description = "AWS managed prometheus workspace name."
+  type        = string
+}

--- a/aws/prometheus-data/versions.tf
+++ b/aws/prometheus-data/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 0.13.0"
+  required_providers {
+    aws = {
+      version = "~> 3.0"
+    }
+  }
+}


### PR DESCRIPTION
This module will build a datasource object to be used to connect to AWS managed prometheus using flightdeck.