### PR TITLE
Use EKS cluster name as Prometheus cluster label

### DIFF
--- a/aws/platform/main.tf
+++ b/aws/platform/main.tf
@@ -273,6 +273,9 @@ locals {
                   ]
                 }
               ]
+              externalLabels = {
+                cluster = var.cluster_name
+              }
               remoteWrite = [
                 {
                   queueConfig = {

--- a/platform/federated-prometheus.yaml
+++ b/platform/federated-prometheus.yaml
@@ -14,6 +14,6 @@ prometheus:
         - 'flightdeck-prometheus.kube-prometheus-stack.svc:9090'
 
     # https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-ingest-dedupe.html
-    prometheusExternalLabelName: cluster
+    prometheusExternalLabelName: prometheus
     replicaExternalLabelName: __replica__
     replicas: 2


### PR DESCRIPTION
This will currently be the name of the Prometheus instance, which is always "federated-prometheus." This results in duplicate samples during blue/green cluster migrations.

This updates the cluster label to use the name of the EKS cluster so that filtering or aggregation between clusters is possible.
