### PR TITLE
Upgrade Prometheus adapter chart

### DIFF
--- a/charts.json
+++ b/charts.json
@@ -47,7 +47,7 @@
   "prometheus-adapter": {
     "chart": "prometheus-adapter",
     "repository": "https://prometheus-community.github.io/helm-charts",
-    "version": "3.0.2"
+    "version": "3.0.3"
   },
   "prometheus-operator": {
     "chart": "kube-prometheus-stack",

--- a/platform/modules/prometheus-adapter/chart.json
+++ b/platform/modules/prometheus-adapter/chart.json
@@ -1,5 +1,5 @@
 {
   "chart": "prometheus-adapter",
   "repository": "https://prometheus-community.github.io/helm-charts",
-  "version": "3.0.2"
+  "version": "3.0.3"
 }


### PR DESCRIPTION
The deployed version has a permissions issue preventing HPAs from accessing external metrics.
