### PR TITLE
Query histogram metrics in Prometheus adapter

### DIFF
--- a/platform/modules/prometheus-adapter/rules.yaml
+++ b/platform/modules/prometheus-adapter/rules.yaml
@@ -123,3 +123,14 @@ external:
     matches: "^(.*)_seconds"
     as: "${1}_seconds"
   metricsQuery: (max(<<.Series>>{<<.LabelMatchers>>}) by (namespace, queue, queue_name))
+
+# Histogram
+- seriesQuery: '{__name__=~".*_app_.*bucket$",namespace!=""}'
+  resources:
+    overrides:
+      namespace:
+        resource: namespace
+  name:
+    matches: "^(.*)_bucket"
+    as: "${1}_95p"
+  metricsQuery: (histogram_quantile(0.95, sum(rate(<<.Series>>{<<.LabelMatchers>>}[5m])) by (namespace, le)))


### PR DESCRIPTION
This pulls any histogram metrics scraped from an application into Prometheus adapter, which is used to implement the Kubernetes metrics pipeline. These are the only metrics available to horizontal pod autoscalers.

These metrics are useful for scaling in response to SLIs.
