### PR TITLE
Only page on critical alarms

### DIFF
--- a/platform/modules/prometheus-operator/main.tf
+++ b/platform/modules/prometheus-operator/main.tf
@@ -60,7 +60,16 @@ locals {
           )
 
           route = {
-            receiver = coalesce(local.pagerduty_route, local.opsgenie_route, "null")
+            receiver = "null"
+
+            routes = [
+              {
+                receiver = coalesce(local.pagerduty_route, local.opsgenie_route, "null")
+                matchers = [
+                  "severity =~ \"critical\""
+                ]
+              }
+            ]
           }
         }
       }


### PR DESCRIPTION
Rather than sending every alarm to Pagerduty or OpsGenie, only send alarms labelled as "critical."
