### PR TITLE
Fix broken reference to garbage collected commit

### DIFF
--- a/aws/grafana-auth/README.md
+++ b/aws/grafana-auth/README.md
@@ -17,8 +17,8 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_rotation"></a> [rotation](#module\_rotation) | github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function | ac7f2ac |
-| <a name="module_secret"></a> [secret](#module\_secret) | github.com/thoughtbot/terraform-aws-secrets//secret | v0.1.0 |
+| <a name="module_rotation"></a> [rotation](#module\_rotation) | github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function | v0.3.1 |
+| <a name="module_secret"></a> [secret](#module\_secret) | github.com/thoughtbot/terraform-aws-secrets//secret | v0.3.1 |
 
 ## Resources
 

--- a/aws/grafana-auth/main.tf
+++ b/aws/grafana-auth/main.tf
@@ -1,5 +1,5 @@
 module "secret" {
-  source = "github.com/thoughtbot/terraform-aws-secrets//secret?ref=v0.1.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//secret?ref=v0.3.1"
 
   admin_principals = var.admin_principals
   description      = "Grafana API Key: ${var.name}"
@@ -14,7 +14,7 @@ module "secret" {
 }
 
 module "rotation" {
-  source = "github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function?ref=ac7f2ac"
+  source = "github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function?ref=v0.3.1"
 
   handler       = "lambda_function.lambda_handler"
   role_arn      = module.secret.rotation_role_arn


### PR DESCRIPTION
- This commit is longer available after a rebase
- Using a tag is more stable than a commit reference
