### PR TITLE
Update alert-manager port name

### DIFF
--- a/platform/modules/prometheus-instance/chart/values.yaml
+++ b/platform/modules/prometheus-instance/chart/values.yaml
@@ -12,7 +12,7 @@ prometheus:
       name: kube-prometheus-stack-alertmanager
       namespace: kube-prometheus-stack
       pathPrefix: /
-      port: web
+      port: http-web
     externalLabels: {}
     disableCompaction: false
     enableAdminAPI: false


### PR DESCRIPTION
The alert-manager port name was changed from `web` to `http-web` from version `23.0.0` of the `kube-prometheus-stack` helm chart. This update will enable this `prometheus-instance` helm chart to find the alert-manager instance deployed by the `kube-prometheus-stack` chart.