### PR TITLE
Update aws provider to version 4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
     - name: Setup TFLint
       uses: terraform-linters/setup-tflint@v1
       with:
-        tflint_version: v0.29.0
+        tflint_version: v0.38.1
 
     - name: Lint
       run: make all/lint

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,6 +1,6 @@
 plugin "aws" {
   enabled = true
-  version = "0.4.1"
+  version = "0.15.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -2,4 +2,4 @@ helm 3.5.2
 kubectl 1.20.2
 terraform 0.15.5
 terraform-docs 0.16.0
-tflint 0.29.0
+tflint 0.38.1

--- a/aws/cluster/README.md
+++ b/aws/cluster/README.md
@@ -64,13 +64,13 @@ module "cluster" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 
 ## Modules
 

--- a/aws/cluster/main.tf
+++ b/aws/cluster/main.tf
@@ -69,7 +69,6 @@ resource "aws_ssm_parameter" "node_role_arn" {
 }
 
 data "aws_subnet" "private" {
-  for_each = module.network.private_subnet_ids
-
+  for_each = toset(module.network.private_subnet_ids)
   id = each.value
 }

--- a/aws/cluster/main.tf
+++ b/aws/cluster/main.tf
@@ -70,5 +70,5 @@ resource "aws_ssm_parameter" "node_role_arn" {
 
 data "aws_subnet" "private" {
   for_each = toset(module.network.private_subnet_ids)
-  id = each.value
+  id       = each.value
 }

--- a/aws/cluster/modules/eks-cluster/README.md
+++ b/aws/cluster/modules/eks-cluster/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 
 ## Resources
 

--- a/aws/cluster/modules/eks-cluster/versions.tf
+++ b/aws/cluster/modules/eks-cluster/versions.tf
@@ -2,7 +2,8 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     aws = {
-      version = "~> 3.0"
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
   }
 }

--- a/aws/cluster/modules/eks-node-group/README.md
+++ b/aws/cluster/modules/eks-node-group/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 
 ## Resources
 

--- a/aws/cluster/modules/eks-node-group/versions.tf
+++ b/aws/cluster/modules/eks-node-group/versions.tf
@@ -2,7 +2,8 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     aws = {
-      version = "~> 3.0"
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
   }
 }

--- a/aws/cluster/modules/eks-node-role/README.md
+++ b/aws/cluster/modules/eks-node-role/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 
 ## Resources
 

--- a/aws/cluster/modules/eks-node-role/versions.tf
+++ b/aws/cluster/modules/eks-node-role/versions.tf
@@ -2,7 +2,8 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     aws = {
-      version = "~> 3.0"
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
   }
 }

--- a/aws/cluster/modules/k8s-oidc-provider/README.md
+++ b/aws/cluster/modules/k8s-oidc-provider/README.md
@@ -4,14 +4,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 3.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 3.1 |
 
 ## Resources

--- a/aws/cluster/modules/k8s-oidc-provider/versions.tf
+++ b/aws/cluster/modules/k8s-oidc-provider/versions.tf
@@ -2,7 +2,8 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     aws = {
-      version = "~> 3.0"
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
     tls = {
       version = "~> 3.1"

--- a/aws/cluster/versions.tf
+++ b/aws/cluster/versions.tf
@@ -2,7 +2,8 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     aws = {
-      version = "~> 3.0"
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
   }
 }

--- a/aws/grafana-auth/README.md
+++ b/aws/grafana-auth/README.md
@@ -4,21 +4,21 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 | <a name="requirement_grafana"></a> [grafana](#requirement\_grafana) | ~> 1.13 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_rotation"></a> [rotation](#module\_rotation) | github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function | v0.3.1 |
-| <a name="module_secret"></a> [secret](#module\_secret) | github.com/thoughtbot/terraform-aws-secrets//secret | v0.3.1 |
+| <a name="module_rotation"></a> [rotation](#module\_rotation) | github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function | v0.4.0 |
+| <a name="module_secret"></a> [secret](#module\_secret) | github.com/thoughtbot/terraform-aws-secrets//secret | v0.4.0 |
 
 ## Resources
 

--- a/aws/grafana-auth/main.tf
+++ b/aws/grafana-auth/main.tf
@@ -1,5 +1,5 @@
 module "secret" {
-  source = "github.com/thoughtbot/terraform-aws-secrets//secret?ref=v0.3.1"
+  source = "github.com/thoughtbot/terraform-aws-secrets//secret?ref=v0.4.0"
 
   admin_principals = var.admin_principals
   description      = "Grafana API Key: ${var.name}"
@@ -14,7 +14,7 @@ module "secret" {
 }
 
 module "rotation" {
-  source = "github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function?ref=v0.3.1"
+  source = "github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function?ref=v0.4.0"
 
   handler       = "lambda_function.lambda_handler"
   role_arn      = module.secret.rotation_role_arn

--- a/aws/grafana-auth/versions.tf
+++ b/aws/grafana-auth/versions.tf
@@ -2,7 +2,8 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     aws = {
-      version = "~> 3.0"
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
     grafana = {
       source  = "grafana/grafana"

--- a/aws/grafana-data-sources/README.md
+++ b/aws/grafana-data-sources/README.md
@@ -4,14 +4,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 | <a name="requirement_grafana"></a> [grafana](#requirement\_grafana) | ~> 1.13 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 | <a name="provider_grafana"></a> [grafana](#provider\_grafana) | ~> 1.13 |
 
 ## Resources

--- a/aws/grafana-data-sources/versions.tf
+++ b/aws/grafana-data-sources/versions.tf
@@ -2,7 +2,8 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     aws = {
-      version = "~> 3.0"
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
     grafana = {
       source  = "grafana/grafana"

--- a/aws/ingress/README.md
+++ b/aws/ingress/README.md
@@ -95,13 +95,13 @@ module "ingress" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.45 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_alb"></a> [alb](#module\_alb) | github.com/thoughtbot/terraform-alb-ingress | 131b6f8 |
+| <a name="module_alb"></a> [alb](#module\_alb) | github.com/thoughtbot/terraform-alb-ingress | v0.5.0 |
 | <a name="module_cluster_name"></a> [cluster\_name](#module\_cluster\_name) | ../cluster-name | n/a |
 | <a name="module_network"></a> [network](#module\_network) | ../network-data | n/a |
 

--- a/aws/ingress/main.tf
+++ b/aws/ingress/main.tf
@@ -1,6 +1,7 @@
 module "alb" {
+  # TODO: update ref when merged into main
   providers = { aws.cluster = aws.cluster, aws.route53 = aws.route53 }
-  source    = "github.com/thoughtbot/terraform-alb-ingress?ref=131b6f8"
+  source    = "github.com/thoughtbot/terraform-alb-ingress?ref=v0.5.0"
 
   alarm_actions             = var.alarm_actions
   alarm_evaluation_minutes  = var.alarm_evaluation_minutes

--- a/aws/ingress/versions.tf
+++ b/aws/ingress/versions.tf
@@ -4,7 +4,7 @@ terraform {
     aws = {
       configuration_aliases = [aws.cluster, aws.route53]
       source                = "hashicorp/aws"
-      version               = "~> 3.45"
+      version               = "~> 4.0"
     }
   }
 }

--- a/aws/network-data/README.md
+++ b/aws/network-data/README.md
@@ -4,20 +4,20 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [aws_subnet_ids.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
-| [aws_subnet_ids.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
+| [aws_subnets.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
+| [aws_subnets.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 | [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
 ## Inputs

--- a/aws/network-data/main.tf
+++ b/aws/network-data/main.tf
@@ -10,22 +10,12 @@ data "aws_subnets" "private" {
   tags = merge(var.tags, var.private_tags)
 }
 
-data "aws_subnet" "private" {
-  for_each = toset(data.aws_subnets.private.ids)
-  id       = each.value
-}
-
 data "aws_subnets" "public" {
   filter {
     name   = "vpc-id"
     values = [data.aws_vpc.this.id]
   }
   tags = merge(var.tags, var.public_tags)
-}
-
-data "aws_subnet" "public" {
-  for_each = toset(data.aws_subnets.public.ids)
-  id       = each.value
 }
 
 locals {

--- a/aws/network-data/main.tf
+++ b/aws/network-data/main.tf
@@ -2,14 +2,30 @@ data "aws_vpc" "this" {
   tags = merge(var.tags, var.vpc_tags)
 }
 
-data "aws_subnet_ids" "private" {
-  tags   = merge(var.tags, var.private_tags)
-  vpc_id = data.aws_vpc.this.id
+data "aws_subnets" "private" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.this.id]
+  }
+  tags = merge(var.tags, var.private_tags)
 }
 
-data "aws_subnet_ids" "public" {
-  tags   = merge(var.tags, var.public_tags)
-  vpc_id = data.aws_vpc.this.id
+data "aws_subnet" "private" {
+  for_each = toset(data.aws_subnets.private.ids)
+  id       = each.value
+}
+
+data "aws_subnets" "public" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.this.id]
+  }
+  tags = merge(var.tags, var.public_tags)
+}
+
+data "aws_subnet" "public" {
+  for_each = toset(data.aws_subnets.public.ids)
+  id       = each.value
 }
 
 locals {

--- a/aws/network-data/outputs.tf
+++ b/aws/network-data/outputs.tf
@@ -10,12 +10,12 @@ output "cidr_blocks" {
 
 output "private_subnet_ids" {
   description = "Private subnets for this network"
-  value       = data.aws_subnet_ids.private.ids
+  value       = data.aws_subnets.private.ids
 }
 
 output "public_subnet_ids" {
   description = "Private subnets for this network"
-  value       = data.aws_subnet_ids.public.ids
+  value       = data.aws_subnets.public.ids
 }
 
 output "vpc" {

--- a/aws/network-data/versions.tf
+++ b/aws/network-data/versions.tf
@@ -2,7 +2,8 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     aws = {
-      version = "~> 3.0"
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
   }
 }

--- a/aws/network/README.md
+++ b/aws/network/README.md
@@ -54,13 +54,13 @@ module "network" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 
 ## Modules
 

--- a/aws/network/modules/nat-gateway/README.md
+++ b/aws/network/modules/nat-gateway/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 
 ## Resources
 

--- a/aws/network/modules/nat-gateway/versions.tf
+++ b/aws/network/modules/nat-gateway/versions.tf
@@ -2,7 +2,8 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     aws = {
-      version = "~> 3.0"
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
   }
 }

--- a/aws/network/modules/private-subnet-routes/README.md
+++ b/aws/network/modules/private-subnet-routes/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 
 ## Resources
 

--- a/aws/network/modules/private-subnet-routes/versions.tf
+++ b/aws/network/modules/private-subnet-routes/versions.tf
@@ -2,7 +2,8 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     aws = {
-      version = "~> 3.0"
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
   }
 }

--- a/aws/network/modules/private-subnets/README.md
+++ b/aws/network/modules/private-subnets/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 
 ## Resources
 

--- a/aws/network/modules/private-subnets/versions.tf
+++ b/aws/network/modules/private-subnets/versions.tf
@@ -2,7 +2,8 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     aws = {
-      version = "~> 3.0"
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
   }
 }

--- a/aws/network/modules/public-subnet-routes/README.md
+++ b/aws/network/modules/public-subnet-routes/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 
 ## Resources
 

--- a/aws/network/modules/public-subnet-routes/versions.tf
+++ b/aws/network/modules/public-subnet-routes/versions.tf
@@ -2,7 +2,8 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     aws = {
-      version = "~> 3.0"
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
   }
 }

--- a/aws/network/modules/public-subnets/README.md
+++ b/aws/network/modules/public-subnets/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 
 ## Resources
 

--- a/aws/network/modules/public-subnets/versions.tf
+++ b/aws/network/modules/public-subnets/versions.tf
@@ -2,7 +2,8 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     aws = {
-      version = "~> 3.0"
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
   }
 }

--- a/aws/network/modules/vpc/README.md
+++ b/aws/network/modules/vpc/README.md
@@ -8,13 +8,13 @@ Module for creating a VPC in AWS.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 
 ## Resources
 

--- a/aws/network/modules/vpc/versions.tf
+++ b/aws/network/modules/vpc/versions.tf
@@ -2,7 +2,8 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     aws = {
-      version = "~> 3.0"
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
   }
 }

--- a/aws/network/versions.tf
+++ b/aws/network/versions.tf
@@ -2,7 +2,8 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     aws = {
-      version = "~> 3.0"
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
   }
 }

--- a/aws/platform/README.md
+++ b/aws/platform/README.md
@@ -120,13 +120,13 @@ You can then use it to manually edit the aws-auth ConfigMap:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 
 ## Modules
 

--- a/aws/platform/modules/auth-config-map/README.md
+++ b/aws/platform/modules/auth-config-map/README.md
@@ -4,14 +4,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | 3.1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | 3.1.0 |
 
 ## Resources

--- a/aws/platform/modules/auth-config-map/versions.tf
+++ b/aws/platform/modules/auth-config-map/versions.tf
@@ -2,7 +2,8 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     aws = {
-      version = "~> 3.0"
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/aws/platform/modules/cloudwatch-logs/README.md
+++ b/aws/platform/modules/cloudwatch-logs/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 
 ## Modules
 

--- a/aws/platform/modules/cloudwatch-logs/versions.tf
+++ b/aws/platform/modules/cloudwatch-logs/versions.tf
@@ -2,7 +2,8 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     aws = {
-      version = "~> 3.0"
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
   }
 }

--- a/aws/platform/modules/cluster-autoscaler-service-account-role/README.md
+++ b/aws/platform/modules/cluster-autoscaler-service-account-role/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 
 ## Modules
 

--- a/aws/platform/modules/cluster-autoscaler-service-account-role/versions.tf
+++ b/aws/platform/modules/cluster-autoscaler-service-account-role/versions.tf
@@ -2,7 +2,8 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     aws = {
-      version = "~> 3.0"
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
   }
 }

--- a/aws/platform/modules/dns-service-account-role/README.md
+++ b/aws/platform/modules/dns-service-account-role/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 
 ## Modules
 

--- a/aws/platform/modules/dns-service-account-role/versions.tf
+++ b/aws/platform/modules/dns-service-account-role/versions.tf
@@ -2,7 +2,8 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     aws = {
-      version = "~> 3.0"
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
   }
 }

--- a/aws/platform/modules/load-balancer-controller/README.md
+++ b/aws/platform/modules/load-balancer-controller/README.md
@@ -11,14 +11,14 @@ target group bound to the Istio ingress gateway service.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.4 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | ~> 2.4 |
 
 ## Modules

--- a/aws/platform/modules/load-balancer-controller/chart.json
+++ b/aws/platform/modules/load-balancer-controller/chart.json
@@ -1,5 +1,5 @@
 {
   "chart": "aws-load-balancer-controller",
   "repository": "https://aws.github.io/eks-charts",
-  "version": "1.4.0"
+  "version": "1.4.2"
 }

--- a/aws/platform/modules/load-balancer-controller/versions.tf
+++ b/aws/platform/modules/load-balancer-controller/versions.tf
@@ -2,7 +2,8 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     aws = {
-      version = "~> 3.0"
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/aws/platform/modules/prometheus-service-account-role/README.md
+++ b/aws/platform/modules/prometheus-service-account-role/README.md
@@ -10,13 +10,13 @@ monitoring account.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 
 ## Modules
 

--- a/aws/platform/modules/prometheus-service-account-role/versions.tf
+++ b/aws/platform/modules/prometheus-service-account-role/versions.tf
@@ -2,7 +2,8 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     aws = {
-      version = "~> 3.0"
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
   }
 }

--- a/aws/platform/versions.tf
+++ b/aws/platform/versions.tf
@@ -2,7 +2,8 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     aws = {
-      version = "~> 3.0"
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
   }
 }

--- a/aws/prometheus-data/README.md
+++ b/aws/prometheus-data/README.md
@@ -8,13 +8,13 @@ Creates a prometheus datasource object containing the necessary details to conne
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 
 ## Resources
 

--- a/aws/prometheus-data/versions.tf
+++ b/aws/prometheus-data/versions.tf
@@ -2,7 +2,8 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     aws = {
-      version = "~> 3.0"
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
   }
 }

--- a/aws/prometheus-workspace/README.md
+++ b/aws/prometheus-workspace/README.md
@@ -11,13 +11,13 @@ write to the workspace.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 
 ## Resources
 

--- a/aws/prometheus-workspace/versions.tf
+++ b/aws/prometheus-workspace/versions.tf
@@ -2,7 +2,8 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     aws = {
-      version = "~> 3.0"
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
   }
 }

--- a/aws/service-account-policy/README.md
+++ b/aws/service-account-policy/README.md
@@ -36,13 +36,13 @@ access to AWS services for your pods.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.45 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.45 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 
 ## Resources
 

--- a/aws/service-account-policy/versions.tf
+++ b/aws/service-account-policy/versions.tf
@@ -2,7 +2,8 @@ terraform {
   required_version = ">= 0.14.0"
   required_providers {
     aws = {
-      version = "~> 3.45"
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
   }
 }

--- a/aws/service-account-role/README.md
+++ b/aws/service-account-role/README.md
@@ -51,13 +51,13 @@ access to AWS services for your pods.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 
 ## Resources
 

--- a/aws/service-account-role/versions.tf
+++ b/aws/service-account-role/versions.tf
@@ -2,7 +2,8 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     aws = {
-      version = "~> 3.0"
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
   }
 }

--- a/aws/target-groups/README.md
+++ b/aws/target-groups/README.md
@@ -119,7 +119,7 @@ module "ingress" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 
 ## Modules
 

--- a/aws/target-groups/versions.tf
+++ b/aws/target-groups/versions.tf
@@ -2,7 +2,8 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     aws = {
-      version = "~> 3.0"
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
   }
 }

--- a/platform/modules/cert-manager/chart.json
+++ b/platform/modules/cert-manager/chart.json
@@ -1,5 +1,5 @@
 {
   "chart": "cert-manager",
   "repository": "https://charts.jetstack.io",
-  "version": "v1.7.1"
+  "version": "v1.8.0"
 }

--- a/platform/modules/cluster-autoscaler/chart.json
+++ b/platform/modules/cluster-autoscaler/chart.json
@@ -1,5 +1,5 @@
 {
   "chart": "cluster-autoscaler",
   "repository": "https://kubernetes.github.io/autoscaler",
-  "version": "9.16.0"
+  "version": "9.18.1"
 }

--- a/platform/modules/external-dns/chart.json
+++ b/platform/modules/external-dns/chart.json
@@ -1,5 +1,5 @@
 {
   "chart": "external-dns",
   "repository": "https://charts.bitnami.com/bitnami",
-  "version": "6.1.8"
+  "version": "6.4.4"
 }

--- a/platform/modules/fluent-bit/chart.json
+++ b/platform/modules/fluent-bit/chart.json
@@ -1,5 +1,5 @@
 {
   "chart": "fluent-bit",
   "repository": "https://fluent.github.io/helm-charts",
-  "version": "0.19.20"
+  "version": "0.20.1"
 }

--- a/platform/modules/istio-base/chart.json
+++ b/platform/modules/istio-base/chart.json
@@ -1,5 +1,5 @@
 {
   "chart": "base",
   "repository": "https://istio-release.storage.googleapis.com/charts",
-  "version": "1.13.1"
+  "version": "1.13.4"
 }

--- a/platform/modules/istio-ingress/chart.json
+++ b/platform/modules/istio-ingress/chart.json
@@ -1,5 +1,5 @@
 {
   "chart": "gateway",
   "repository": "https://istio-release.storage.googleapis.com/charts",
-  "version": "1.13.1"
+  "version": "1.13.4"
 }

--- a/platform/modules/istiod/chart.json
+++ b/platform/modules/istiod/chart.json
@@ -1,5 +1,5 @@
 {
   "chart": "istiod",
   "repository": "https://istio-release.storage.googleapis.com/charts",
-  "version": "1.13.1"
+  "version": "1.13.4"
 }

--- a/platform/modules/prometheus-operator/chart.json
+++ b/platform/modules/prometheus-operator/chart.json
@@ -1,5 +1,5 @@
 {
   "chart": "kube-prometheus-stack",
   "repository": "https://prometheus-community.github.io/helm-charts",
-  "version": "33.0.0"
+  "version": "35.3.1"
 }

--- a/platform/modules/reloader/chart.json
+++ b/platform/modules/reloader/chart.json
@@ -1,5 +1,5 @@
 {
   "chart": "reloader",
   "repository": "https://stakater.github.io/stakater-charts",
-  "version": "v0.0.105"
+  "version": "v0.0.110"
 }

--- a/platform/modules/secret-store-driver/chart.json
+++ b/platform/modules/secret-store-driver/chart.json
@@ -1,5 +1,5 @@
 {
   "chart": "secrets-store-csi-driver",
   "repository": "https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts",
-  "version": "1.1.0"
+  "version": "1.1.2"
 }


### PR DESCRIPTION
## TODOs
- [x] Merge related PRs
  - [x] https://github.com/thoughtbot/terraform-alb-ingress/pull/9
  - [x] https://github.com/thoughtbot/terraform-aws-secrets/pull/5
  - [x] https://github.com/thoughtbot/terraform-s3-bucket/pull/2
  - [x] https://github.com/thoughtbot/terraform-eks-cicd/pull/9
  - [x] https://github.com/thoughtbot/terraform-aws-sso-permission-set-roles/pull/1
  - [x] https://github.com/thoughtbot/terraform-aws-ses-smtp-credentials/pull/1
  - [x] https://github.com/thoughtbot/terraform-aws-sentry-dsn/pull/1
  - [x] https://github.com/thoughtbot/terraform-ses-domain-identity/pull/3
  - [x] https://github.com/thoughtbot/terraform-aws-databases/pull/4
- [x] check for s3_bucket and other deprecations outlined in [terraform provider upgrade docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade)
- [x] test `terraform plan` on various infra repos to ensure no changes with updated flightdeck
- [x] update topic branch references in this PR to release versions once those are merged / tagged
- [ ] update readme refs to flightdeck version once new tag is created
- [ ] final integration testing with repos using flightdeck