### PR TITLE
Add workspace name to the prometheus datasource module output

### DIFF
--- a/aws/prometheus-data/main.tf
+++ b/aws/prometheus-data/main.tf
@@ -13,5 +13,8 @@ data "aws_s3_bucket_object" "prometheus" {
 
 locals {
   prometheus_workspace_json = join("", data.aws_s3_bucket_object.prometheus.*.body)
-  prometheus_data           = jsondecode(local.prometheus_workspace_json)
+  prometheus_data = merge(
+    jsondecode(local.prometheus_workspace_json),
+    { "name" : var.aws_prometheus_workspace_name }
+  )
 }


### PR DESCRIPTION
The `prometheus_data_source` variable in platform module is expecting `name` as part of the keys in the input map.
This update will include name as part of the output for the prometheus datasource module.