### PR TITLE
Additional permissions are required on the EKS node to use opentelemetry

### DIFF
--- a/aws/cluster/modules/eks-node-role/README.md
+++ b/aws/cluster/modules/eks-node-role/README.md
@@ -18,8 +18,11 @@
 |------|------|
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.ec2_container_registry_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.eks_cloudwatch_agent_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.eks_cni_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.eks_ssm_instance_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.eks_worker_node_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.eks_xray_writeonly_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 

--- a/aws/cluster/modules/eks-node-role/main.tf
+++ b/aws/cluster/modules/eks-node-role/main.tf
@@ -29,6 +29,21 @@ resource "aws_iam_role_policy_attachment" "ec2_container_registry_policy" {
   role       = aws_iam_role.this.name
 }
 
+resource "aws_iam_role_policy_attachment" "eks_cloudwatch_agent_policy" {
+  policy_arn = "${local.policy_prefix}/CloudWatchAgentServerPolicy"
+  role       = aws_iam_role.this.name
+}
+
+resource "aws_iam_role_policy_attachment" "eks_ssm_instance_policy" {
+  policy_arn = "${local.policy_prefix}/AmazonSSMManagedInstanceCore"
+  role       = aws_iam_role.this.name
+}
+
+resource "aws_iam_role_policy_attachment" "eks_xray_writeonly_policy" {
+  policy_arn = "${local.policy_prefix}/AWSXrayWriteOnlyAccess"
+  role       = aws_iam_role.this.name
+}
+
 locals {
   policy_prefix = "arn:${data.aws_partition.current.partition}:iam::aws:policy"
 }


### PR DESCRIPTION
Additional permissions are required on the EKS node to use opentelemetry collector on EKS

- CloudWatchAgentServerPolicy - Permissions required to use AmazonCloudWatchAgent on servers
- AmazonSSMManagedInstanceCore - The policy for Amazon EC2 Role to enable AWS Systems Manager service core functionality.
- AWSXrayWriteOnlyAccess - Allow the AWS X-Ray Daemon to relay raw trace segments data to the service's API and retrieve sampling data (rules, targets, etc.) to be used by the X-Ray SDK.