### PR TITLE
Expose http Prometheus metrics to autoscaling

### DIFF
--- a/platform/modules/prometheus-adapter/rules.yaml
+++ b/platform/modules/prometheus-adapter/rules.yaml
@@ -57,6 +57,19 @@ custom:
     as: "${1}_per_second"
   metricsQuery: (sum(irate(<<.Series>>{<<.LabelMatchers>>}[1m])) by (<<.GroupBy>>))
 
+# Expose http histograms (request rate, queue duration) as 95th percentile
+- seriesQuery: '{__name__=~".*_http_.*bucket$",namespace!=""}'
+  resources:
+    overrides:
+      namespace:
+        resource: namespace
+      service:
+        resource: service
+  name:
+    matches: "^(.*)_bucket"
+    as: "${1}_95p1m"
+  metricsQuery: (histogram_quantile(0.95, sum(rate(<<.Series>>{<<.LabelMatchers>>}[1m])) by (le, job, namespace, service)))
+
 # These metrics are for non-pod aggregated metrics like queue lengths
 external:
 


### PR DESCRIPTION
Our typical setup with the prometheus_exporter gem will send metrics like `ruby_http_requests_per_second` and `ruby_http_queue_duration_seconds`. These metrics are useful for autoscaling web pods, so it's useful to expose them by default.
