### PR TITLE
Delete cluster before node role

### DIFF
--- a/aws/cluster/main.tf
+++ b/aws/cluster/main.tf
@@ -24,6 +24,8 @@ module "eks_cluster" {
   public_subnet_ids         = module.network.public_subnet_ids
   tags                      = var.tags
   vpc                       = module.network.vpc
+
+  depends_on = [module.node_role]
 }
 
 module "node_role" {


### PR DESCRIPTION
Currently, when running `terraform destroy` for a cluster, it will delete the IAM role used by EKS nodes before the cluster is fully deleted. This results in elastic network interfaces and security groups potentially being orphaned after the cluster is deleted as the cluster loses permission to clean up the resources it created.

This uses `depends_on` to ensure that the IAM role is preserved until the cluster is fully deleted.
