### PR TITLE
Use latest version of official Sloth chart

### DIFF
--- a/charts.json
+++ b/charts.json
@@ -68,5 +68,10 @@
     "chart": "secrets-store-csi-driver",
     "repository": "https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts",
     "version": "1.3.0"
+  },
+  "sloth": {
+    "chart": "sloth",
+    "repository": "https://slok.github.io/sloth",
+    "version": "0.11.0"
   }
 }

--- a/platform/README.md
+++ b/platform/README.md
@@ -101,6 +101,8 @@ practices.
 | <a name="input_reloader_version"></a> [reloader\_version](#input\_reloader\_version) | Version of external-dns to install | `string` | `null` | no |
 | <a name="input_secret_store_driver_values"></a> [secret\_store\_driver\_values](#input\_secret\_store\_driver\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_secret_store_driver_version"></a> [secret\_store\_driver\_version](#input\_secret\_store\_driver\_version) | Version of the secret store driver to install | `string` | `null` | no |
+| <a name="input_sloth_values"></a> [sloth\_values](#input\_sloth\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
+| <a name="input_sloth_version"></a> [sloth\_version](#input\_sloth\_version) | Version of Sloth to install | `string` | `null` | no |
 | <a name="input_vertical_pod_autoscaler_values"></a> [vertical\_pod\_autoscaler\_values](#input\_vertical\_pod\_autoscaler\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 
 ## Outputs

--- a/platform/main.tf
+++ b/platform/main.tf
@@ -188,6 +188,10 @@ module "reloader" {
 module "sloth" {
   source = "./modules/sloth"
 
+  chart_values  = var.sloth_values
+  chart_version = var.sloth_version
+  k8s_namespace = local.flightdeck_namespace
+
   depends_on = [module.prometheus_operator]
 }
 

--- a/platform/modules/sloth/README.md
+++ b/platform/modules/sloth/README.md
@@ -24,9 +24,10 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_chart_name"></a> [chart\_name](#input\_chart\_name) | Helm chart to install | `string` | `"sloth"` | no |
-| <a name="input_chart_repository"></a> [chart\_repository](#input\_chart\_repository) | Helm repository containing the chart | `string` | `"https://flightdeck-charts.s3.amazonaws.com/sloth"` | no |
+| <a name="input_chart_name"></a> [chart\_name](#input\_chart\_name) | Helm chart to install | `string` | `null` | no |
+| <a name="input_chart_repository"></a> [chart\_repository](#input\_chart\_repository) | Helm repository containing the chart | `string` | `null` | no |
+| <a name="input_chart_values"></a> [chart\_values](#input\_chart\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
+| <a name="input_chart_version"></a> [chart\_version](#input\_chart\_version) | Version of Sloth Chart to be installed | `string` | `null` | no |
 | <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | Kubernetes namespace in which the gateway should be installed | `string` | `"flightdeck"` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of this Helm release | `string` | `"sloth"` | no |
-| <a name="input_sloth_version"></a> [sloth\_version](#input\_sloth\_version) | Version of Sloth Chart to be installed | `string` | `"0.3.0"` | no |
 <!-- END_TF_DOCS -->

--- a/platform/modules/sloth/chart.json
+++ b/platform/modules/sloth/chart.json
@@ -1,0 +1,5 @@
+{
+  "chart": "sloth",
+  "repository": "https://slok.github.io/sloth",
+  "version": "0.11.0"
+}

--- a/platform/modules/sloth/main.tf
+++ b/platform/modules/sloth/main.tf
@@ -1,7 +1,12 @@
 resource "helm_release" "sloth" {
-  chart      = var.chart_name
+  chart      = coalesce(var.chart_name, local.chart_defaults.chart)
   name       = var.name
   namespace  = var.k8s_namespace
-  repository = var.chart_repository
-  version    = var.sloth_version
+  repository = coalesce(var.chart_repository, local.chart_defaults.repository)
+  values     = var.chart_values
+  version    = coalesce(var.chart_version, local.chart_defaults.version)
+}
+
+locals {
+  chart_defaults = jsondecode(file("${path.module}/chart.json"))
 }

--- a/platform/modules/sloth/variables.tf
+++ b/platform/modules/sloth/variables.tf
@@ -1,19 +1,25 @@
 variable "chart_name" {
   type        = string
   description = "Helm chart to install"
-  default     = "sloth"
+  default     = null
 }
 
 variable "chart_repository" {
   type        = string
   description = "Helm repository containing the chart"
-  default     = "https://flightdeck-charts.s3.amazonaws.com/sloth"
+  default     = null
 }
 
-variable "sloth_version" {
+variable "chart_values" {
+  description = "Overrides to pass to the Helm chart"
+  type        = list(string)
+  default     = []
+}
+
+variable "chart_version" {
   type        = string
   description = "Version of Sloth Chart to be installed"
-  default     = "0.3.0"
+  default     = null
 }
 
 variable "k8s_namespace" {

--- a/platform/variables.tf
+++ b/platform/variables.tf
@@ -196,6 +196,18 @@ variable "secret_store_driver_version" {
   default     = null
 }
 
+variable "sloth_values" {
+  description = "Overrides to pass to the Helm chart"
+  type        = list(string)
+  default     = []
+}
+
+variable "sloth_version" {
+  type        = string
+  description = "Version of Sloth to install"
+  default     = null
+}
+
 variable "vertical_pod_autoscaler_values" {
   description = "Overrides to pass to the Helm chart"
   type        = list(string)


### PR DESCRIPTION
There is now an official Helm chart for Sloth we can use, and we are many versions behind.

This switches from our custom chart to use the official chart and bumps the version.
