### PR TITLE
Create log groups per Kubernetes namespace

### DIFF
--- a/aws/platform/README.md
+++ b/aws/platform/README.md
@@ -186,6 +186,7 @@ You can then use it to manually edit the aws-auth ConfigMap:
 | <a name="input_istio_ingress_values"></a> [istio\_ingress\_values](#input\_istio\_ingress\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_istiod_values"></a> [istiod\_values](#input\_istiod\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | Kubernetes namespace in which resources should be created | `string` | `"flightdeck"` | no |
+| <a name="input_logs_prefix"></a> [logs\_prefix](#input\_logs\_prefix) | Prefix for CloudWatch log groups | `string` | `"/flightdeck"` | no |
 | <a name="input_logs_retention_in_days"></a> [logs\_retention\_in\_days](#input\_logs\_retention\_in\_days) | Number of days for which logs should be retained | `number` | `30` | no |
 | <a name="input_metrics_server_values"></a> [metrics\_server\_values](#input\_metrics\_server\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_metrics_server_version"></a> [metrics\_server\_version](#input\_metrics\_server\_version) | Version of the Metrics Server to install | `string` | `null` | no |

--- a/aws/platform/main.tf
+++ b/aws/platform/main.tf
@@ -122,6 +122,7 @@ module "cloudwatch_logs" {
   cluster_full_name = module.cluster_name.full
   aws_tags          = var.aws_tags
   k8s_namespace     = var.k8s_namespace
+  log_group_prefix  = var.logs_prefix
   retention_in_days = var.logs_retention_in_days
   oidc_issuer       = data.aws_ssm_parameter.oidc_issuer.value
 }
@@ -370,7 +371,10 @@ locals {
             Match *
             region ${data.aws_region.current.name}
             log_group_name ${module.cloudwatch_logs.log_group_name}
+            log_group_template ${var.logs_prefix}/$kubernetes['namespace_name']
             log_stream_prefix $${HOST_NAME}-
+            log_stream_template $kubernetes['pod_name'].$kubernetes['container_name']
+            log_retention_days ${var.logs_retention_in_days}
         EOT
       }
       env = [
@@ -385,7 +389,7 @@ locals {
       ]
       image = {
         repository = "public.ecr.aws/aws-observability/aws-for-fluent-bit"
-        tag        = "2.22.0"
+        tag        = "2.31.6"
       }
       resources = {
         limits = {

--- a/aws/platform/modules/cloudwatch-logs/README.md
+++ b/aws/platform/modules/cloudwatch-logs/README.md
@@ -25,7 +25,10 @@
 | [aws_cloudwatch_log_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_iam_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
@@ -35,6 +38,7 @@
 | <a name="input_aws_tags"></a> [aws\_tags](#input\_aws\_tags) | Tags to be applied to created AWS resources | `map(string)` | `{}` | no |
 | <a name="input_cluster_full_name"></a> [cluster\_full\_name](#input\_cluster\_full\_name) | Full name of the cluster which will write to this log group | `string` | n/a | yes |
 | <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | Kubernetes namespace in which resources should be created | `string` | n/a | yes |
+| <a name="input_log_group_prefix"></a> [log\_group\_prefix](#input\_log\_group\_prefix) | Prefix for log groups for Flightdeck applications | `string` | `"/flightdeck"` | no |
 | <a name="input_oidc_issuer"></a> [oidc\_issuer](#input\_oidc\_issuer) | OIDC issuer of the Kubernetes cluster | `string` | n/a | yes |
 | <a name="input_retention_in_days"></a> [retention\_in\_days](#input\_retention\_in\_days) | Number of days to retain logs | `number` | `30` | no |
 

--- a/aws/platform/modules/cloudwatch-logs/variables.tf
+++ b/aws/platform/modules/cloudwatch-logs/variables.tf
@@ -20,6 +20,12 @@ variable "k8s_namespace" {
   description = "Kubernetes namespace in which resources should be created"
 }
 
+variable "log_group_prefix" {
+  type        = string
+  description = "Prefix for log groups for Flightdeck applications"
+  default     = "/flightdeck"
+}
+
 variable "oidc_issuer" {
   type        = string
   description = "OIDC issuer of the Kubernetes cluster"

--- a/aws/platform/variables.tf
+++ b/aws/platform/variables.tf
@@ -152,6 +152,12 @@ variable "logs_retention_in_days" {
   description = "Number of days for which logs should be retained"
 }
 
+variable "logs_prefix" {
+  type        = string
+  description = "Prefix for CloudWatch log groups"
+  default     = "/flightdeck"
+}
+
 variable "metrics_server_values" {
   description = "Overrides to pass to the Helm chart"
   type        = list(string)


### PR DESCRIPTION
Newer versions of Fluent Bit have a feature called "Record Accessor Syntax" which allows you to interpolate labels from a log entry into the filter settings. This allows us to make a log group based on the Kubernetes namespace. You still need to have a default log group as a fallback.

This contains the following changes:

- Retain cluster logs up to the retention period rather than deleting them with the cluster
- Create a log group based on the Kubernetes namespace
- Create a log stream based on the pod and container
- Allow Fluent Bit to create log groups in the given prefix
