### PR TITLE
Add module to create deploy service account

### DIFF
--- a/aws/deploy-service-account/README.md
+++ b/aws/deploy-service-account/README.md
@@ -1,0 +1,78 @@
+# Deploy Service Account
+
+This module creates a [Kubernetes service account] which can be used to write to
+common resources used by Flightdeck applications, suitable for use in a CI/CD
+pipeline.
+
+Example:
+
+``` hcl
+module "deploy_service_account" {
+  source = "github.com/thoughtbot/flightdeck//aws/deploy-service-account?ref=VERSION"
+
+  # Name of the service account (default: deploy)
+  name = "example-staging-deploy"
+
+  # Kubernetes namespace
+  namespace = "example-staging"
+
+  # Must match a group declared in your eks-auth configmap
+  group = "example-staging-deploy"
+}
+```
+
+You can use the [github-actions-eks-deploy-role module] to create a role
+suitable for use in a GitHub Actions workflow.
+
+Once the deploy service account and role have been created, you must map them in
+your [eks-auth] config:
+
+``` hcl
+# In your platform configuration
+module "workload_platform" {
+  source = "github.com/thoughtbot/flightdeck//aws/platform?ref=VERSION"
+
+  # Other config
+
+  custom_roles = {
+    # Must match the group binding above
+    example-staging-deploy = aws_iam_role.example_staging_deploy.arn
+  }
+}
+```
+
+[Kubernetes service account]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+[eks-auth]: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
+[github-actions-eks-deploy-role module]: github.com/thoughtbot/terraform-eks-cicd//modules/github-actions-eks-deploy-role
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.5 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.6 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.6 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [kubernetes_role.deploy_crd](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role) | resource |
+| [kubernetes_role_binding.cluster](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role_binding) | resource |
+| [kubernetes_role_binding.crd](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role_binding) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cluster_roles"></a> [cluster\_roles](#input\_cluster\_roles) | Names of cluster roles for this serviceaccount (default: admin) | `list(string)` | <pre>[<br>  "admin"<br>]</pre> | no |
+| <a name="input_group"></a> [group](#input\_group) | Name of the Kubernetes group allowed to deploy | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name of the Kubernetes service account (default: deploy) | `string` | `"deploy"` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Kubernetes namespace to which this tenant deploys | `string` | n/a | yes |
+<!-- END_TF_DOCS -->

--- a/aws/deploy-service-account/main.tf
+++ b/aws/deploy-service-account/main.tf
@@ -1,0 +1,64 @@
+resource "kubernetes_role_binding" "cluster" {
+  for_each = toset(var.cluster_roles)
+
+  metadata {
+    name      = var.name
+    namespace = var.namespace
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = each.value
+  }
+
+  subject {
+    kind      = "Group"
+    name      = var.group
+    api_group = "rbac.authorization.k8s.io"
+  }
+}
+
+resource "kubernetes_role_binding" "crd" {
+  metadata {
+    name      = kubernetes_role.deploy_crd.metadata[0].name
+    namespace = var.namespace
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = "${var.name}-crd"
+  }
+
+  subject {
+    kind      = "Group"
+    name      = var.group
+    api_group = "rbac.authorization.k8s.io"
+  }
+}
+
+resource "kubernetes_role" "deploy_crd" {
+  metadata {
+    name      = "${var.name}-crd"
+    namespace = var.namespace
+  }
+
+  rule {
+    api_groups = ["monitoring.coreos.com"]
+    resources  = ["servicemonitors"]
+    verbs      = ["*"]
+  }
+
+  rule {
+    api_groups = ["networking.istio.io"]
+    resources  = ["virtualservices"]
+    verbs      = ["*"]
+  }
+
+  rule {
+    api_groups = ["sloth.slok.dev"]
+    resources  = ["prometheusservicelevels"]
+    verbs      = ["*"]
+  }
+}

--- a/aws/deploy-service-account/makefile
+++ b/aws/deploy-service-account/makefile
@@ -1,0 +1,67 @@
+MODULEFILES := $(wildcard *.tf)
+TFLINTRC    ?= ../../.tflint.hcl
+TFDOCSRC    ?= ../../.terraform-docs.yml
+
+.PHONY: default
+default: checkfmt validate docs lint
+
+.PHONY: checkfmt
+checkfmt: .fmt
+
+.PHONY: fmt
+fmt: $(MODULEFILES)
+	terraform fmt
+	@touch .fmt
+
+.PHONY: validate
+validate: .validate
+
+.PHONY: docs
+docs: README.md
+
+.PHONY: lint
+lint: .lint
+
+.lint: $(MODULEFILES) .lintinit
+	tflint --config=$(TFLINTRC)
+	@touch .lint
+
+.lintinit: $(TFLINTRC)
+	tflint --init --config=$(TFLINTRC) --module
+	@touch .lintinit
+
+README.md: $(MODULEFILES)
+	terraform-docs --config "$(TFDOCSRC)" markdown table . --output-file README.md
+
+.fmt: $(MODULEFILES)
+	terraform fmt -check
+	@touch .fmt
+
+.PHONY: init
+init: .init
+
+.init: versions.tf .dependencies
+	terraform init -backend=false
+	@touch .init
+
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
+
+.dependencies: *.tf
+	@grep -ohE \
+		"\b(backend|provider|resource|module) ['\"][[:alpha:]][[:alnum:]]*|\bsource  *=.*" *.tf | \
+		sed "s/['\"]//" | sort | uniq | \
+		tee /tmp/initdeps | \
+		diff -q .dependencies - >/dev/null 2>&1 || \
+		mv /tmp/initdeps .dependencies
+
+.PHONY: clean
+clean:
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/aws/deploy-service-account/variables.tf
+++ b/aws/deploy-service-account/variables.tf
@@ -1,0 +1,21 @@
+variable "cluster_roles" {
+  description = "Names of cluster roles for this serviceaccount (default: admin)"
+  type        = list(string)
+  default     = ["admin"]
+}
+
+variable "group" {
+  description = "Name of the Kubernetes group allowed to deploy"
+  type        = string
+}
+
+variable "name" {
+  description = "Name of the Kubernetes service account (default: deploy)"
+  type        = string
+  default     = "deploy"
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace to which this tenant deploys"
+  type        = string
+}

--- a/aws/deploy-service-account/versions.tf
+++ b/aws/deploy-service-account/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.15.5"
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.6"
+    }
+  }
+}


### PR DESCRIPTION
This adds a module to create a service account capable of deploying an application to a Flightdeck cluster. It provides broad permissions to the service account within a specific namespace, including built-in Kubernetes resources and the CRDs introduced by Flightdeck.
