### PR TITLE
Add module for creating developer service accounts

### DIFF
--- a/aws/developer-service-account/README.md
+++ b/aws/developer-service-account/README.md
@@ -1,0 +1,84 @@
+# Developer Service Account
+
+This module creates a [Kubernetes service account] which can be used by
+developers to debug Flightdeck applications. It provides read access to most
+Kubernetes resources within the namespace, including the CRDs declared by
+Flightdeck.
+
+Example:
+
+``` hcl
+module "developer_service_account" {
+  source = "github.com/thoughtbot/flightdeck//aws/developer-service-account?ref=VERSION"
+
+  # Name of the service account (default: developer)
+  name = "example-staging-developer"
+
+  # Kubernetes namespace
+  namespace = "example-staging"
+
+  # Must match a group declared in your eks-auth configmap
+  group = "example-staging-developer"
+
+  # Uncomment if you want developers to be able to use kubectl exec
+  # enable_exec = true
+}
+```
+
+Once the service account has been created, you must map them in your [eks-auth]
+config. You can use the [SSO permission set roles module] to lookup a role that
+developers will use.
+
+
+``` hcl
+# In your platform configuration
+module "sso_roles" {
+  source = "git@github.com:thoughtbot/terraform-aws-sso-permission-set-roles.git?ref=v0.2.0"
+}
+
+module "platform" {
+  source = "github.com/thoughtbot/flightdeck//aws/platform?ref=v0.9.0-alpha.0"
+
+  # Other config
+
+  custom_roles = {
+    example-developer  module.permission_set_roles.by_name_without_path.DeveloperAccess
+  }
+}
+
+```
+
+[Kubernetes service account]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+[eks-auth]: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
+[SSO permission set roles module]: https://github.com/thoughtbot/terraform-aws-sso-permission-set-roles
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.5 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.6 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.6 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [kubernetes_role.developer_access](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role) | resource |
+| [kubernetes_role_binding.developer_access](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role_binding) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_enable_exec"></a> [enable\_exec](#input\_enable\_exec) | Set to true to allow running exec on pods | `bool` | `false` | no |
+| <a name="input_group"></a> [group](#input\_group) | Name of the Kubernetes group used by developers | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name of the Kubernetes service account (default: developer) | `string` | `"developer"` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Kubernetes namespace to which developers will have access | `string` | n/a | yes |
+<!-- END_TF_DOCS -->

--- a/aws/developer-service-account/main.tf
+++ b/aws/developer-service-account/main.tf
@@ -1,0 +1,74 @@
+resource "kubernetes_role_binding" "developer_access" {
+  metadata {
+    name      = var.name
+    namespace = var.namespace
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = "developer"
+  }
+
+  subject {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Group"
+    name      = var.group
+  }
+}
+
+resource "kubernetes_role" "developer_access" {
+  metadata {
+    name      = var.name
+    namespace = var.namespace
+  }
+
+  # Read-only access to non-sensitive resources
+  rule {
+    api_groups = ["", "apps", "batch"]
+    resources = [
+      "configmaps",
+      "cronjobs",
+      "daemonsets",
+      "deployments",
+      "jobs",
+      "pods",
+      "pods/log",
+      "replicasets",
+      "services",
+    ]
+    verbs = ["get", "list", "watch"]
+  }
+
+  # View Prometheus Operator resources
+  rule {
+    api_groups = ["monitoring.coreos.com"]
+    resources  = ["servicemonitors"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  # View Istio resources
+  rule {
+    api_groups = ["networking.istio.io"]
+    resources  = ["virtualservices"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  # View Sloth SLOs
+  rule {
+    api_groups = ["sloth.slok.dev"]
+    resources  = ["prometheusservicelevels"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  # Exec into pods for debugging
+  dynamic "rule" {
+    for_each = var.enable_exec ? [true] : []
+
+    content {
+      api_groups = [""]
+      resources  = ["pods/exec"]
+      verbs      = ["get", "create"]
+    }
+  }
+}

--- a/aws/developer-service-account/makefile
+++ b/aws/developer-service-account/makefile
@@ -1,0 +1,67 @@
+MODULEFILES := $(wildcard *.tf)
+TFLINTRC    ?= ../../.tflint.hcl
+TFDOCSRC    ?= ../../.terraform-docs.yml
+
+.PHONY: default
+default: checkfmt validate docs lint
+
+.PHONY: checkfmt
+checkfmt: .fmt
+
+.PHONY: fmt
+fmt: $(MODULEFILES)
+	terraform fmt
+	@touch .fmt
+
+.PHONY: validate
+validate: .validate
+
+.PHONY: docs
+docs: README.md
+
+.PHONY: lint
+lint: .lint
+
+.lint: $(MODULEFILES) .lintinit
+	tflint --config=$(TFLINTRC)
+	@touch .lint
+
+.lintinit: $(TFLINTRC)
+	tflint --init --config=$(TFLINTRC) --module
+	@touch .lintinit
+
+README.md: $(MODULEFILES)
+	terraform-docs --config "$(TFDOCSRC)" markdown table . --output-file README.md
+
+.fmt: $(MODULEFILES)
+	terraform fmt -check
+	@touch .fmt
+
+.PHONY: init
+init: .init
+
+.init: versions.tf .dependencies
+	terraform init -backend=false
+	@touch .init
+
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
+
+.dependencies: *.tf
+	@grep -ohE \
+		"\b(backend|provider|resource|module) ['\"][[:alpha:]][[:alnum:]]*|\bsource  *=.*" *.tf | \
+		sed "s/['\"]//" | sort | uniq | \
+		tee /tmp/initdeps | \
+		diff -q .dependencies - >/dev/null 2>&1 || \
+		mv /tmp/initdeps .dependencies
+
+.PHONY: clean
+clean:
+	rm -rf .dependencies .fmt .init .lint .lintinit .terraform* .validate

--- a/aws/developer-service-account/variables.tf
+++ b/aws/developer-service-account/variables.tf
@@ -1,0 +1,21 @@
+variable "enable_exec" {
+  description = "Set to true to allow running exec on pods"
+  type        = bool
+  default     = false
+}
+
+variable "group" {
+  description = "Name of the Kubernetes group used by developers"
+  type        = string
+}
+
+variable "name" {
+  description = "Name of the Kubernetes service account (default: developer)"
+  type        = string
+  default     = "developer"
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace to which developers will have access"
+  type        = string
+}

--- a/aws/developer-service-account/versions.tf
+++ b/aws/developer-service-account/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.15.5"
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.6"
+    }
+  }
+}


### PR DESCRIPTION
This introduces a module for creating a Kubernetes service account suitable for developer to use for debugging. This avoids the need to assign cluster administrator roles to most developers.
