### PR TITLE
Add IP addresses for NAT gateways to outputs

### DIFF
--- a/aws/network/README.md
+++ b/aws/network/README.md
@@ -107,5 +107,6 @@ module "network" {
 | Name | Description |
 |------|-------------|
 | <a name="output_cluster_names"></a> [cluster\_names](#output\_cluster\_names) | List of clusters which run in this network |
+| <a name="output_nat_ip_addresses"></a> [nat\_ip\_addresses](#output\_nat\_ip\_addresses) | List of IP addresses created for NAT gateways |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | ID of the AWS VPC |
 <!-- END_TF_DOCS -->

--- a/aws/network/modules/nat-gateway/README.md
+++ b/aws/network/modules/nat-gateway/README.md
@@ -34,4 +34,5 @@
 | Name | Description |
 |------|-------------|
 | <a name="output_instances"></a> [instances](#output\_instances) | The created NAT gateways for each availability zone |
+| <a name="output_ip_addresses"></a> [ip\_addresses](#output\_ip\_addresses) | IP addresses created for NAT gateways |
 <!-- END_TF_DOCS -->

--- a/aws/network/modules/nat-gateway/outputs.tf
+++ b/aws/network/modules/nat-gateway/outputs.tf
@@ -2,3 +2,8 @@ output "instances" {
   description = "The created NAT gateways for each availability zone"
   value       = aws_nat_gateway.this
 }
+
+output "ip_addresses" {
+  description = "IP addresses created for NAT gateways"
+  value       = values(aws_nat_gateway.this)[*].public_ip
+}

--- a/aws/network/outputs.tf
+++ b/aws/network/outputs.tf
@@ -3,6 +3,11 @@ output "cluster_names" {
   value       = var.cluster_names
 }
 
+output "nat_ip_addresses" {
+  description = "List of IP addresses created for NAT gateways"
+  value       = flatten(module.nat_gateway[*].ip_addresses)
+}
+
 output "vpc_id" {
   description = "ID of the AWS VPC"
   value       = local.vpc.id


### PR DESCRIPTION
We sometimes need to add output IP addresses for applications to IP allow lists for external services. This adds the IP addresses to the module outputs so that it's easier to find them.
