### PR TITLE
Restore inline Helm charts for config

### DIFF
--- a/aws/platform/modules/load-balancer-controller/README.md
+++ b/aws/platform/modules/load-balancer-controller/README.md
@@ -13,7 +13,6 @@ target group bound to the Istio ingress gateway service.
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.8 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.4 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.6 |
 
 ## Providers
 
@@ -21,7 +20,6 @@ target group bound to the Istio ingress gateway service.
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | ~> 2.4 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.6 |
 
 ## Modules
 
@@ -35,8 +33,8 @@ target group bound to the Istio ingress gateway service.
 |------|------|
 | [aws_iam_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [helm_release.ingress_config](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.this](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
-| [kubernetes_manifest.target_group_binding](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [aws_lb_target_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb_target_group) | data source |
 
 ## Inputs

--- a/aws/platform/modules/load-balancer-controller/target-group-binding/Chart.yaml
+++ b/aws/platform/modules/load-balancer-controller/target-group-binding/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: target-group-binding
+description: Target group binding for AWS Load Balancer Controller
+
+type: application
+
+version: 0.1.0
+
+appVersion: 1.0.0

--- a/aws/platform/modules/load-balancer-controller/target-group-binding/templates/target-group-binding.yaml
+++ b/aws/platform/modules/load-balancer-controller/target-group-binding/templates/target-group-binding.yaml
@@ -1,0 +1,14 @@
+apiVersion: elbv2.k8s.aws/v1beta1
+kind: TargetGroupBinding
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  networking:
+    ingress:
+      {{ toYaml .Values.networking.ingress | indent 6 | trim }}
+  serviceRef:
+    name: {{ .Values.serviceRef.name }}
+    port: {{ .Values.serviceRef.port }}
+  targetGroupARN: {{ .Values.targetGroupARN }}
+  targetType: {{ .Values.targetType }}

--- a/aws/platform/modules/load-balancer-controller/target-group-binding/values.yaml
+++ b/aws/platform/modules/load-balancer-controller/target-group-binding/values.yaml
@@ -1,0 +1,17 @@
+nameOverride: ""
+fullnameOverride: ""
+
+name: ""
+
+destination:
+  server: https://kubernetes.default.svc
+
+networking:
+  ingress: []
+
+serviceRef:
+  name: ""
+  port: 443
+
+targetGroupARN: ""
+targetType: ip

--- a/aws/platform/modules/load-balancer-controller/versions.tf
+++ b/aws/platform/modules/load-balancer-controller/versions.tf
@@ -9,9 +9,5 @@ terraform {
       source  = "hashicorp/helm"
       version = "~> 2.4"
     }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = "~> 2.6"
-    }
   }
 }

--- a/platform/modules/ingress-config/README.md
+++ b/platform/modules/ingress-config/README.md
@@ -4,21 +4,19 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.8 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.6 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.4 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.6 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | ~> 2.4 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [kubernetes_manifest.certificate](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
-| [kubernetes_manifest.gateway](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
-| [kubernetes_manifest.issuer](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
+| [helm_release.ingress_config](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 
 ## Inputs
 
@@ -27,4 +25,5 @@
 | <a name="input_domain_names"></a> [domain\_names](#input\_domain\_names) | Domains which are allowed in this cluster | `list(string)` | `[]` | no |
 | <a name="input_issuer"></a> [issuer](#input\_issuer) | YAML spec for the cert-manager issuer | `string` | `null` | no |
 | <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | Kubernetes namespace in which secrets should be created | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name for the Helm release | `string` | `"ingress-config"` | no |
 <!-- END_TF_DOCS -->

--- a/platform/modules/ingress-config/chart/Chart.yaml
+++ b/platform/modules/ingress-config/chart/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: ingress-config
+description: Configuration for Flightdeck ingress
+
+type: application
+
+version: 0.1.0
+
+appVersion: 1.0.0

--- a/platform/modules/ingress-config/chart/templates/certificate.yaml
+++ b/platform/modules/ingress-config/chart/templates/certificate.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.certificate.create -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: flightdeck
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: flightdeck-tls
+  duration: 2160h
+  renewBefore: 360h
+  subject:
+    organizations:
+    - flightdeck
+  isCA: false
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 2048
+  usages:
+    - server auth
+    - client auth
+  dnsNames:
+    {{ toYaml .Values.certificate.domains | indent 4 | trim }}
+  issuerRef:
+    name: {{ .Values.certificate.issuer.name }}
+    kind: {{ .Values.certificate.issuer.kind }}
+{{- end -}}

--- a/platform/modules/ingress-config/chart/templates/gateway.yaml
+++ b/platform/modules/ingress-config/chart/templates/gateway.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: flightdeck
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    {{- toYaml .Values.gateway.selector | nindent 4 }}
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
+    tls:
+      httpsRedirect: {{ .Values.gateway.requireTLS }}
+  - port:
+      number: 443
+      name: https
+      protocol: HTTPS
+    hosts:
+    - "*"
+    tls:
+      mode: SIMPLE
+      credentialName: flightdeck-tls

--- a/platform/modules/ingress-config/chart/templates/issuer.yaml
+++ b/platform/modules/ingress-config/chart/templates/issuer.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.certificate.issuer.create -}}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ .Values.certificate.issuer.name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  {{ toYaml .Values.certificate.issuer.spec | indent 2 | trim }}
+{{- end -}}

--- a/platform/modules/ingress-config/chart/values.yaml
+++ b/platform/modules/ingress-config/chart/values.yaml
@@ -1,0 +1,23 @@
+nameOverride: ""
+fullnameOverride: ""
+
+destination:
+  server: https://kubernetes.default.svc
+
+certificate:
+  create: true
+  domains: []
+  issuer:
+    create: true
+    name: flightdeck
+    spec:
+      selfSigned: {}
+
+gateway:
+  requireTLS: true
+  selector:
+    istio: flightdeck-ingressgateway
+
+ingress:
+  host: ""
+  requireTLS: true

--- a/platform/modules/ingress-config/main.tf
+++ b/platform/modules/ingress-config/main.tf
@@ -1,107 +1,21 @@
-resource "kubernetes_manifest" "certificate" {
-  manifest = {
-    apiVersion = "cert-manager.io/v1"
-    kind       = "Certificate"
-
-    metadata = {
-      name      = "flightdeck"
-      namespace = var.k8s_namespace
-    }
-
-    spec = {
-      dnsNames    = var.domain_names
-      duration    = "2160h"
-      isCA        = false
-      renewBefore = "360h"
-      secretName  = "flightdeck-tls"
-      subject     = { organizations = ["flightdeck"] }
-      usages      = ["server auth", "client auth"]
-
-      issuerRef = {
-        kind = local.issuer.kind
-        name = local.issuer.name
-      }
-
-      privateKey = {
-        algorithm = "RSA"
-        encoding  = "PKCS1"
-        size      = 2048
-      }
-    }
-  }
-}
-
-resource "kubernetes_manifest" "gateway" {
-  manifest = {
-    apiVersion = "networking.istio.io/v1alpha3"
-    kind       = "Gateway"
-
-    metadata = {
-      name      = "flightdeck"
-      namespace = var.k8s_namespace
-    }
-
-    spec = {
-      selector = {
-        istio = "flightdeck-ingressgateway"
-      }
-
-      servers = [
-        {
-          hosts = ["*"]
-
-          port = {
-            name     = "http"
-            number   = 80
-            protocol = "HTTP"
-          }
-
-          tls = {
-            httpsRedirect = true
-          }
-        },
-        {
-          hosts = ["*"]
-          port = {
-            name     = "https"
-            number   = 443
-            protocol = "HTTPS"
-          }
-          tls = {
-            credentialName = "flightdeck-tls"
-            mode           = "SIMPLE"
-          }
-        },
-      ]
-    }
-  }
-}
-
-resource "kubernetes_manifest" "issuer" {
-  count = try(local.issuer.create, true) ? 1 : 0
-
-  manifest = {
-    apiVersion = "cert-manager.io/v1"
-    kind       = "Issuer"
-
-    metadata = {
-      name      = local.issuer.name
-      namespace = var.k8s_namespace
-    }
-
-    spec = yamlencode(local.issuer.spec)
-  }
+resource "helm_release" "ingress_config" {
+  chart     = "${path.module}/chart"
+  name      = var.name
+  namespace = var.k8s_namespace
+  values    = local.chart_values
 }
 
 locals {
-  issuer = (
-    var.issuer == null ?
-    {
-      name = "flightdeck"
-      spec = {
-        selfSigned = {}
-      }
-    } :
-    yamldecode(var.issuer)
-  )
+  chart_values = [yamlencode({
+    certificate = merge(
+      {
+        domains = var.domain_names
+      },
+      (
+        var.issuer == null ?
+        {} :
+        { issuer = yamldecode(var.issuer) }
+      )
+    )
+  })]
 }

--- a/platform/modules/ingress-config/variables.tf
+++ b/platform/modules/ingress-config/variables.tf
@@ -14,3 +14,9 @@ variable "k8s_namespace" {
   type        = string
   description = "Kubernetes namespace in which secrets should be created"
 }
+
+variable "name" {
+  description = "Name for the Helm release"
+  type        = string
+  default     = "ingress-config"
+}

--- a/platform/modules/ingress-config/versions.tf
+++ b/platform/modules/ingress-config/versions.tf
@@ -1,9 +1,9 @@
 terraform {
   required_version = ">= 0.14.8"
   required_providers {
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = "~> 2.6"
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.4"
     }
   }
 }


### PR DESCRIPTION
Applying Kubernetes manifests for CRDs in the same apply as the Helm chart currently does not work in the Terraform Kubernetes provider. Attempting to do so results in failures when looking up the CRD version:

https://github.com/thoughtbot/flightdeck/actions/runs/4810820017/jobs/8564458459

We can try doing this again once this issue is resolved:
https://github.com/hashicorp/terraform-provider-kubernetes/issues/1583

This reverts commits:

- d5e8b32dfd4d715e45839eff5b0946e9c61dee70
- 139c284e9cb9211650eed18234f5e762811ffe7a
