### PR TITLE
Fix Sloth chart version

### DIFF
--- a/charts.json
+++ b/charts.json
@@ -77,6 +77,6 @@
   "sloth": {
     "chart": "sloth",
     "repository": "https://slok.github.io/sloth",
-    "version": "0.11.0"
+    "version": "0.7.0"
   }
 }

--- a/platform/modules/sloth/chart.json
+++ b/platform/modules/sloth/chart.json
@@ -1,5 +1,5 @@
 {
   "chart": "sloth",
   "repository": "https://slok.github.io/sloth",
-  "version": "0.11.0"
+  "version": "0.7.0"
 }


### PR DESCRIPTION
The version of the Sloth image is 0.11, but the chart is 0.7.
