### PR TITLE
Automatically run acceptance each month

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -1,6 +1,8 @@
 name: Acceptance
 on:
-- workflow_dispatch
+  schedule:
+  - cron: '0 0 1 * *' # First day of each month
+  workflow_dispatch:
 
 permissions:
   id-token: write


### PR DESCRIPTION
This workflow is cumbersome to run on each pull request as it takes several hours to run, but it's easy to forget to ever run it.

This adds a monthly trigger so that it will run regularly.
