### PR TITLE
Allow metrics with `sli` prefix to be recorded to federated Prometheus

### DIFF
--- a/platform/federated-prometheus.yaml
+++ b/platform/federated-prometheus.yaml
@@ -7,7 +7,7 @@ prometheus:
       metrics_path: '/federate'
       params:
         'match[]':
-          - '{__name__=~"(app|deploy|external|hpa|istio|namespace_cpu|namespace_memory|slo|svc):.*"}'
+          - '{__name__=~"(app|deploy|external|hpa|istio|namespace_cpu|namespace_memory|sli|slo|svc):.*"}'
       static_configs:
       - targets:
         - 'kube-prometheus-stack-prometheus.kube-prometheus-stack.svc:9090'


### PR DESCRIPTION
That way we can establish a pattern for SLI recording rules.