### PR TITLE
Use Grafana's workspace name to set condition for trust policy document

### DIFF
--- a/aws/telemetry/modules/grafana-role/main.tf
+++ b/aws/telemetry/modules/grafana-role/main.tf
@@ -60,7 +60,7 @@ data "aws_iam_policy_document" "trust" {
 
     condition {
       test     = "StringEquals"
-      variable = "iam:ResourceTag/grafana.workspace.${var.name}"
+      variable = "iam:ResourceTag/grafana.workspace.${var.grafana_workspace_name}"
       values   = ["true"]
     }
   }


### PR DESCRIPTION
We were previously using the name of the role for that, which doesn't work if the name of the role is not the same as the name of the workspace.