### PR TITLE
Prevent overriding changes to dashboards created using the module

### DIFF
--- a/aws/grafana-dashboards/main.tf
+++ b/aws/grafana-dashboards/main.tf
@@ -2,4 +2,10 @@ resource "grafana_dashboard" "this" {
   for_each = toset(var.dashboards_to_create)
 
   config_json = file("${path.module}/dashboards/${each.value}.json")
+
+  lifecycle {
+    ignore_changes = [
+      config_json
+    ]
+  }
 }


### PR DESCRIPTION
Because of the nature of how Grafana dashboards are managed, it's very unlikely that someone is going to make changes to the JSON version of the dashboards rather than making updates directly to the UI. The goal of the grafana-dashboards module is to just create the starter dashboards, and then the user can customize it as they would like without sticking to Flightdeck's initial version.

This change will ensure that once the dashboards are created, terraform won't try to revert changes that the user makes to the UI whenever they try to make changes to resources that use this module.