### PR TITLE
Fix matchers for Alertmanager routing rules

### DIFF
--- a/aws/telemetry/modules/prometheus-workspace/main.tf
+++ b/aws/telemetry/modules/prometheus-workspace/main.tf
@@ -102,7 +102,7 @@ locals {
           receiver = name
 
           matchers = [
-            "severity = ${name}"
+            "severity =~ ${name}"
           ]
         }
       ]


### PR DESCRIPTION
The comparison only works if we use the "=~" operator to match severities for alerts.