### PR TITLE
Allow kms to receive a custom alias name 

### DIFF
--- a/aws/telemetry/README.md
+++ b/aws/telemetry/README.md
@@ -61,6 +61,7 @@ module "telemetry" {
 | <a name="input_alert_subject_template"></a> [alert\_subject\_template](#input\_alert\_subject\_template) | Template used for AlertManager alert subjects | `string` | `null` | no |
 | <a name="input_grafana_role_name"></a> [grafana\_role\_name](#input\_grafana\_role\_name) | Name of the IAM role created for Grafana | `string` | `"grafana"` | no |
 | <a name="input_grafana_workspace_name"></a> [grafana\_workspace\_name](#input\_grafana\_workspace\_name) | Name of the Grafana workspace which will use telemetry resources | `string` | `"Grafana"` | no |
+| <a name="input_kms_alias_name"></a> [kms\_alias\_name](#input\_kms\_alias\_name) | KMS alias name for SNS topics | `string` | `"alias/sns-alarm-topics"` | no |
 | <a name="input_monitoring_account_ids"></a> [monitoring\_account\_ids](#input\_monitoring\_account\_ids) | AWS account IDs in which Grafana will run | `list(string)` | `null` | no |
 | <a name="input_prometheus_workspace_name"></a> [prometheus\_workspace\_name](#input\_prometheus\_workspace\_name) | Name of the AWS Managed Prometheus workspace | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to created resources | `map(string)` | `{}` | no |

--- a/aws/telemetry/main.tf
+++ b/aws/telemetry/main.tf
@@ -11,6 +11,8 @@ module "sns_topics" {
       "${source}-${severity}"
     ]
   ])
+
+  kms_alias_name = var.kms_alias_name
 }
 
 module "prometheus_workspace" {

--- a/aws/telemetry/modules/sns-topics/README.md
+++ b/aws/telemetry/modules/sns-topics/README.md
@@ -37,6 +37,7 @@ contents are encrypted at rest using KMS.
 |------|-------------|------|---------|:--------:|
 | <a name="input_admin_principals"></a> [admin\_principals](#input\_admin\_principals) | IAM principals allowed to manage this topic (defaults to current account) | `list(string)` | `[]` | no |
 | <a name="input_enable_kms"></a> [enable\_kms](#input\_enable\_kms) | Set to false to disable encryption with KMS | `bool` | `true` | no |
+| <a name="input_kms_alias_name"></a> [kms\_alias\_name](#input\_kms\_alias\_name) | KMS alias name for SNS topics | `string` | n/a | yes |
 | <a name="input_sns_topic_names"></a> [sns\_topic\_names](#input\_sns\_topic\_names) | Names of SNS topics for alarms | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to created resources | `map(string)` | `{}` | no |
 

--- a/aws/telemetry/modules/sns-topics/main.tf
+++ b/aws/telemetry/modules/sns-topics/main.tf
@@ -73,7 +73,7 @@ data "aws_iam_policy_document" "sns" {
 resource "aws_kms_alias" "sns" {
   count = length(aws_kms_key.sns)
 
-  name          = "alias/sns-alarm-topics"
+  name          = var.kms_alias_name
   target_key_id = aws_kms_key.sns[count.index].id
 }
 

--- a/aws/telemetry/modules/sns-topics/variables.tf
+++ b/aws/telemetry/modules/sns-topics/variables.tf
@@ -15,6 +15,11 @@ variable "sns_topic_names" {
   type        = list(string)
 }
 
+variable "kms_alias_name" {
+  description = "KMS alias name for SNS topics"
+  type        = string
+}
+
 variable "tags" {
   description = "Tags to be applied to created resources"
   type        = map(string)

--- a/aws/telemetry/variables.tf
+++ b/aws/telemetry/variables.tf
@@ -68,3 +68,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "kms_alias_name" {
+  description = "KMS alias name for SNS topics"
+  type        = string
+  default     = "alias/sns-alarm-topics"
+}


### PR DESCRIPTION
When setting up multiple Prometheus environments, the telemetry module will try to create a kms alias with the same name as the first one that was created. This change aids that to allow adding a custom kms alias name.