### PR TITLE
More control on AWS EKS configurations

### DIFF
--- a/aws/cluster/main.tf
+++ b/aws/cluster/main.tf
@@ -39,15 +39,18 @@ module "node_groups" {
   for_each = var.node_groups
   source   = "./modules/eks-node-group"
 
-  cluster        = module.eks_cluster.instance
-  instance_types = each.value.instance_types
-  max_size       = each.value.max_size
-  min_size       = each.value.min_size
-  name           = each.key
-  namespace      = [module.cluster_name.full]
-  role           = module.node_role.instance
-  subnets        = values(data.aws_subnet.private)
-  tags           = var.tags
+  cluster         = module.eks_cluster.instance
+  instance_types  = each.value.instance_types
+  max_size        = each.value.max_size
+  min_size        = each.value.min_size
+  capacity_type   = each.value.capacity_type
+  max_unavailable = each.value.max_unavailable
+  name            = each.key
+  namespace       = [module.cluster_name.full]
+  role            = module.node_role.instance
+  subnets         = values(data.aws_subnet.private)
+  tags            = var.tags
+  labels          = var.labels
 
   depends_on = [module.node_role]
 }

--- a/aws/cluster/modules/eks-node-group/main.tf
+++ b/aws/cluster/modules/eks-node-group/main.tf
@@ -19,7 +19,7 @@ resource "aws_eks_node_group" "this" {
   }
 
   labels = merge(var.labels, {
-    role = var.node_role
+    role = var.label_node_role
   })
 
   tags = merge(var.tags, {

--- a/aws/cluster/modules/eks-node-group/main.tf
+++ b/aws/cluster/modules/eks-node-group/main.tf
@@ -3,6 +3,7 @@ resource "aws_eks_node_group" "this" {
 
   cluster_name    = var.cluster.name
   instance_types  = var.instance_types
+  capacity_type   = var.capacity_type
   node_group_name = join("-", concat(var.namespace, [var.name, each.key]))
   node_role_arn   = var.role.arn
   subnet_ids      = [each.value.id]
@@ -12,6 +13,14 @@ resource "aws_eks_node_group" "this" {
     max_size     = local.max_size_per_node_group
     min_size     = local.min_size_per_node_group
   }
+
+  update_config {
+    max_unavailable = var.max_unavailable
+  }
+
+  labels = merge(var.labels, {
+    role = var.node_role
+  })
 
   tags = merge(var.tags, {
     AvailabilityZone = each.key

--- a/aws/cluster/modules/eks-node-group/variables.tf
+++ b/aws/cluster/modules/eks-node-group/variables.tf
@@ -57,7 +57,7 @@ variable "labels" {
   default     = {}
 }
 
-variable "node_role" {
+variable "label_node_role" {
   type        = string
   description = "Role to struct kubernetes scheduler to use for this node group"
   default     = "general"

--- a/aws/cluster/modules/eks-node-group/variables.tf
+++ b/aws/cluster/modules/eks-node-group/variables.tf
@@ -45,3 +45,26 @@ variable "tags" {
   description = "Tags to be applied to created resources"
   default     = {}
 }
+variable "capacity_type" {
+  type        = string
+  description = "Instance capacity type ON_DEMAND or SPOT"
+  default     = "ON_DEMAND"
+}
+
+variable "labels" {
+  type        = map(string)
+  description = "Labels to be applied to created resources"
+  default     = {}
+}
+
+variable "node_role" {
+  type        = string
+  description = "Role to struct kubernetes scheduler to use for this node group"
+  default     = "general"
+}
+
+variable "max_unavailable" {
+  type        = number
+  description = "Maximum number of nodes that can be unavailable during a rolling update"
+  default     = 1
+}


### PR DESCRIPTION
Add new variables to apply to the cluster configuration:

- capacity_type: to determine the node capacity type on AWS (ON_DEMAND, SPOT)
- labels: kubernetes labels
- label_node_role: default label called role
- max_unavailable: Max Unavailable nodes during an upgrade