### PR TITLE
Include new cluster configurations (capacity_type, max_unavailable)

### DIFF
--- a/aws/cluster/main.tf
+++ b/aws/cluster/main.tf
@@ -39,15 +39,18 @@ module "node_groups" {
   for_each = var.node_groups
   source   = "./modules/eks-node-group"
 
-  cluster        = module.eks_cluster.instance
-  instance_types = each.value.instance_types
-  max_size       = each.value.max_size
-  min_size       = each.value.min_size
-  name           = each.key
-  namespace      = [module.cluster_name.full]
-  role           = module.node_role.instance
-  subnets        = values(data.aws_subnet.private)
-  tags           = var.tags
+  cluster         = module.eks_cluster.instance
+  instance_types  = each.value.instance_types
+  max_size        = each.value.max_size
+  min_size        = each.value.min_size
+  capacity_type   = each.value.capacity_type
+  max_unavailable = each.value.max_unavailable
+  name            = each.key
+  namespace       = [module.cluster_name.full]
+  role            = module.node_role.instance
+  subnets         = values(data.aws_subnet.private)
+  tags            = var.tags
+  labels          = var.labels
 
   depends_on = [module.node_role]
 }

--- a/aws/cluster/modules/eks-cluster/main.tf
+++ b/aws/cluster/modules/eks-cluster/main.tf
@@ -98,7 +98,7 @@ resource "aws_kms_key" "eks_key" {
 }
 
 resource "aws_kms_alias" "eks_key_alias" {
-  target_key_id = aws_kms_key.eks_key
+  target_key_id = aws_kms_key.eks_key.key_id
   name_prefix   = "alias/${var.name}"
 
   depends_on = [aws_kms_key.eks_key]

--- a/aws/cluster/modules/eks-cluster/main.tf
+++ b/aws/cluster/modules/eks-cluster/main.tf
@@ -18,7 +18,7 @@ resource "aws_eks_cluster" "this" {
     provider {
       key_arn = aws_kms_key.eks_key.arn
     }
-    resources = "secrets"
+    resources = ["secrets"]
   }
 
   depends_on = [

--- a/aws/cluster/modules/eks-cluster/main.tf
+++ b/aws/cluster/modules/eks-cluster/main.tf
@@ -29,7 +29,10 @@ resource "aws_eks_cluster" "this" {
 
     # Ensure EKS doesn't automatically create the log group before we create it
     # and set retention.
-    aws_cloudwatch_log_group.eks
+    aws_cloudwatch_log_group.eks,
+
+    # Ensure that the KMS key is created before EKS Cluster start using it.
+    aws_kms_key.eks_key
   ]
 }
 
@@ -97,6 +100,8 @@ resource "aws_kms_key" "eks_key" {
 resource "aws_kms_alias" "eks_key_alias" {
   target_key_id = aws_kms_key.eks_key
   name_prefix   = "alias/${var.name}"
+
+  depends_on = [aws_kms_key.eks_key]
 }
 
 data "aws_partition" "current" {

--- a/aws/cluster/modules/eks-node-group/main.tf
+++ b/aws/cluster/modules/eks-node-group/main.tf
@@ -19,7 +19,7 @@ resource "aws_eks_node_group" "this" {
   }
 
   labels = merge(var.labels, {
-    role = var.node_role
+    role = var.label_node_role
   })
 
   tags = merge(var.tags, {

--- a/aws/cluster/modules/eks-node-group/main.tf
+++ b/aws/cluster/modules/eks-node-group/main.tf
@@ -3,6 +3,7 @@ resource "aws_eks_node_group" "this" {
 
   cluster_name    = var.cluster.name
   instance_types  = var.instance_types
+  capacity_type   = var.capacity_type
   node_group_name = join("-", concat(var.namespace, [var.name, each.key]))
   node_role_arn   = var.role.arn
   subnet_ids      = [each.value.id]
@@ -12,6 +13,14 @@ resource "aws_eks_node_group" "this" {
     max_size     = local.max_size_per_node_group
     min_size     = local.min_size_per_node_group
   }
+
+  update_config {
+    max_unavailable = var.max_unavailable
+  }
+
+  labels = merge(var.labels, {
+    role = var.node_role
+  })
 
   tags = merge(var.tags, {
     AvailabilityZone = each.key

--- a/aws/cluster/modules/eks-node-group/variables.tf
+++ b/aws/cluster/modules/eks-node-group/variables.tf
@@ -57,7 +57,7 @@ variable "labels" {
   default     = {}
 }
 
-variable "node_role" {
+variable "label_node_role" {
   type        = string
   description = "Role to struct kubernetes scheduler to use for this node group"
   default     = "general"

--- a/aws/cluster/modules/eks-node-group/variables.tf
+++ b/aws/cluster/modules/eks-node-group/variables.tf
@@ -45,3 +45,26 @@ variable "tags" {
   description = "Tags to be applied to created resources"
   default     = {}
 }
+variable "capacity_type" {
+  type        = string
+  description = "Instance capacity type ON_DEMAND or SPOT"
+  default     = "ON_DEMAND"
+}
+
+variable "labels" {
+  type        = map(string)
+  description = "Labels to be applied to created resources"
+  default     = {}
+}
+
+variable "node_role" {
+  type        = string
+  description = "Role to struct kubernetes scheduler to use for this node group"
+  default     = "general"
+}
+
+variable "max_unavailable" {
+  type        = number
+  description = "Maximum number of nodes that can be unavailable during a rolling update"
+  default     = 1
+}

--- a/aws/cluster/variables.tf
+++ b/aws/cluster/variables.tf
@@ -30,9 +30,11 @@ variable "node_groups" {
   description = "Node groups to create in this cluster"
 
   type = map(object({
-    instance_types = list(string),
-    max_size       = number
-    min_size       = number
+    instance_types  = list(string),
+    max_size        = number
+    min_size        = number
+    max_unavailable = number
+    capacity_type   = string
   }))
 }
 

--- a/aws/cluster/variables.tf
+++ b/aws/cluster/variables.tf
@@ -41,3 +41,9 @@ variable "tags" {
   description = "Tags to be applied to all created resources"
   default     = {}
 }
+
+variable "labels" {
+  type        = map(string)
+  description = "Labels to be applied to created resources"
+  default     = {}
+}


### PR DESCRIPTION
We're proposing extend the cluster configurations proposing two new variables:

- capacity_type: responsible to define the type of the instances that will run. The options are ON_DEMAND or SPOT, the default value is ON_DEMAND.
- max_unavailable: define on the cluster creation the max unavailable pods during a update.
- labels: define labels to give anti-affinity configurations flexibility.

BONUS: We're also fixing a problem of the last main version using the AWS KMS for secrets. Sorry for the fix on the same branch.