### PR TITLE
Allow Spot capacity type for AWS node groups

### DIFF
--- a/aws/cluster/README.md
+++ b/aws/cluster/README.md
@@ -100,7 +100,7 @@ module "cluster" {
 | <a name="input_log_retention_in_days"></a> [log\_retention\_in\_days](#input\_log\_retention\_in\_days) | How many days until control plane logs are purged | `number` | `7` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name for this EKS cluster | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Prefix to be applied to created resources | `list(string)` | `[]` | no |
-| <a name="input_node_groups"></a> [node\_groups](#input\_node\_groups) | Node groups to create in this cluster | <pre>map(object({<br>    instance_types = list(string),<br>    max_size       = number<br>    min_size       = number<br>  }))</pre> | n/a | yes |
+| <a name="input_node_groups"></a> [node\_groups](#input\_node\_groups) | Node groups to create in this cluster | <pre>map(object({<br>    capacity_type  = optional(string, "ON_DEMAND")<br>    instance_types = list(string),<br>    max_size       = number<br>    min_size       = number<br>  }))</pre> | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to all created resources | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/aws/cluster/main.tf
+++ b/aws/cluster/main.tf
@@ -39,6 +39,7 @@ module "node_groups" {
   for_each = var.node_groups
   source   = "./modules/eks-node-group"
 
+  capacity_type  = each.value.capacity_type
   cluster        = module.eks_cluster.instance
   instance_types = each.value.instance_types
   max_size       = each.value.max_size

--- a/aws/cluster/modules/eks-node-group/README.md
+++ b/aws/cluster/modules/eks-node-group/README.md
@@ -22,6 +22,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_capacity_type"></a> [capacity\_type](#input\_capacity\_type) | Allow values: ON\_DEMAND (default), SPOT | `string` | `"ON_DEMAND"` | no |
 | <a name="input_cluster"></a> [cluster](#input\_cluster) | Cluster which this node group should join | `object({ name = string })` | n/a | yes |
 | <a name="input_instance_types"></a> [instance\_types](#input\_instance\_types) | EC2 instance types allowed in this node group | `list(string)` | <pre>[<br>  "t3.medium"<br>]</pre> | no |
 | <a name="input_max_size"></a> [max\_size](#input\_max\_size) | Maximum number of nodes in this group | `number` | n/a | yes |

--- a/aws/cluster/modules/eks-node-group/main.tf
+++ b/aws/cluster/modules/eks-node-group/main.tf
@@ -1,6 +1,7 @@
 resource "aws_eks_node_group" "this" {
   for_each = local.subnets
 
+  capacity_type   = var.capacity_type
   cluster_name    = var.cluster.name
   instance_types  = var.instance_types
   node_group_name = join("-", concat(var.namespace, [var.name, each.key]))

--- a/aws/cluster/modules/eks-node-group/variables.tf
+++ b/aws/cluster/modules/eks-node-group/variables.tf
@@ -1,3 +1,9 @@
+variable "capacity_type" {
+  type        = string
+  default     = "ON_DEMAND"
+  description = "Allow values: ON_DEMAND (default), SPOT"
+}
+
 variable "cluster" {
   type        = object({ name = string })
   description = "Cluster which this node group should join"

--- a/aws/cluster/variables.tf
+++ b/aws/cluster/variables.tf
@@ -30,6 +30,7 @@ variable "node_groups" {
   description = "Node groups to create in this cluster"
 
   type = map(object({
+    capacity_type  = optional(string, "ON_DEMAND")
     instance_types = list(string),
     max_size       = number
     min_size       = number


### PR DESCRIPTION
The underlying Terraform resource accepts a capacity type to determine on-demand or spot compute, but we don't currently pass it. This uses the default of on-demand but allows overriding it for creation of Spot node groups.
