### PR TITLE
Update GitHub Actions Node version

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -80,7 +80,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
-        node-version: '14'
+        node-version: '20'
 
     - name: Init
       working-directory: template/${{ inputs.module }}


### PR DESCRIPTION
The most recent GitHub Action to setup Terraform requires NodeJS v20.
