### PR TITLE
Convert jmesPath `object_alias` to `objectAlias`

### DIFF
--- a/aws/secret-provider-class/main.tf
+++ b/aws/secret-provider-class/main.tf
@@ -7,13 +7,22 @@ locals {
       objectName = secret.name
       objectType = "secretsmanager"
 
-      jmesPath = coalescelist(secret.jmes_paths, [
-        for key in secret.environment_variables :
-        {
-          path        = key
-          objectAlias = key
-        }
-      ])
+      jmesPath = coalescelist(
+        [
+          for jmes_path in secret.jmes_paths :
+          {
+            path = jmes_path.path,
+            objectAlias : jmes_path.object_alias
+          }
+        ],
+        [
+          for key in secret.environment_variables :
+          {
+            path        = key
+            objectAlias = key
+          }
+        ]
+      )
     }
   ])
 }


### PR DESCRIPTION
The module expects jmesPath object` definitions with `object_alias` and `path` keys. To be a valid jmesPath, SecretsManager requires converting `object_alias` to its CamelCase equivalent.

Prior to this change no conversion was done which resulted in errors if using `jmesPath`s. To maintain snakecase in the variable definition and keep the documentation accurate, update the module to do the conversion.