### PR TITLE
Add variables to config public and private endpoint access

### DIFF
--- a/aws/cluster/README.md
+++ b/aws/cluster/README.md
@@ -96,6 +96,8 @@ module "cluster" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_enabled_cluster_log_types"></a> [enabled\_cluster\_log\_types](#input\_enabled\_cluster\_log\_types) | Which EKS control plane log types to enable | `list(string)` | `[]` | no |
+| <a name="input_endpoint_private_access"></a> [endpoint\_private\_access](#input\_endpoint\_private\_access) | Enables the Amazon EKS private API server endpoint. | `bool` | `false` | no |
+| <a name="input_endpoint_public_access"></a> [endpoint\_public\_access](#input\_endpoint\_public\_access) | Enables the Amazon EKS public API server endpoint. | `bool` | `true` | no |
 | <a name="input_k8s_version"></a> [k8s\_version](#input\_k8s\_version) | Kubernetes version to deploy | `string` | n/a | yes |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to be applied to created resources | `map(string)` | `{}` | no |
 | <a name="input_log_retention_in_days"></a> [log\_retention\_in\_days](#input\_log\_retention\_in\_days) | How many days until control plane logs are purged | `number` | `7` | no |

--- a/aws/cluster/main.tf
+++ b/aws/cluster/main.tf
@@ -17,6 +17,8 @@ module "eks_cluster" {
   source = "./modules/eks-cluster"
 
   enabled_cluster_log_types = var.enabled_cluster_log_types
+  endpoint_private_access   = var.endpoint_private_access
+  endpoint_public_access    = var.endpoint_public_access
   k8s_version               = var.k8s_version
   log_retention_in_days     = var.log_retention_in_days
   name                      = module.cluster_name.full

--- a/aws/cluster/modules/eks-cluster/README.md
+++ b/aws/cluster/modules/eks-cluster/README.md
@@ -32,6 +32,8 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_enabled_cluster_log_types"></a> [enabled\_cluster\_log\_types](#input\_enabled\_cluster\_log\_types) | Which EKS control plane log types to enable | `list(string)` | <pre>[<br>  "api",<br>  "audit"<br>]</pre> | no |
+| <a name="input_endpoint_private_access"></a> [endpoint\_private\_access](#input\_endpoint\_private\_access) | Enables the Amazon EKS private API server endpoint. | `bool` | `false` | no |
+| <a name="input_endpoint_public_access"></a> [endpoint\_public\_access](#input\_endpoint\_public\_access) | Enables the Amazon EKS public API server endpoint. | `bool` | `true` | no |
 | <a name="input_k8s_version"></a> [k8s\_version](#input\_k8s\_version) | Kubernetes version to deploy | `string` | n/a | yes |
 | <a name="input_log_retention_in_days"></a> [log\_retention\_in\_days](#input\_log\_retention\_in\_days) | How many days until control plane logs are purged | `number` | `7` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name for this EKS cluster | `string` | n/a | yes |

--- a/aws/cluster/modules/eks-cluster/main.tf
+++ b/aws/cluster/modules/eks-cluster/main.tf
@@ -12,6 +12,8 @@ resource "aws_eks_cluster" "this" {
   vpc_config {
     security_group_ids = [aws_security_group.control_plane.id]
     subnet_ids         = concat(var.private_subnet_ids, var.public_subnet_ids)
+    endpoint_private_access = var.endpoint_private_access
+    endpoint_public_access  = var.endpoint_public_access
   }
 
   encryption_config {

--- a/aws/cluster/modules/eks-cluster/variables.tf
+++ b/aws/cluster/modules/eks-cluster/variables.tf
@@ -4,6 +4,18 @@ variable "enabled_cluster_log_types" {
   description = "Which EKS control plane log types to enable"
 }
 
+variable "endpoint_private_access" {
+  type = bool
+  description = "Enables the Amazon EKS private API server endpoint."
+  default = false
+}
+
+variable "endpoint_public_access" {
+  type = bool
+  description = "Enables the Amazon EKS public API server endpoint."
+  default = true
+}
+
 variable "log_retention_in_days" {
   type        = number
   description = "How many days until control plane logs are purged"

--- a/aws/cluster/variables.tf
+++ b/aws/cluster/variables.tf
@@ -4,6 +4,18 @@ variable "enabled_cluster_log_types" {
   description = "Which EKS control plane log types to enable"
 }
 
+variable "endpoint_private_access" {
+  type = bool
+  description = "Enables the Amazon EKS private API server endpoint."
+  default = false
+}
+
+variable "endpoint_public_access" {
+  type = bool
+  description = "Enables the Amazon EKS public API server endpoint."
+  default = true
+}
+
 variable "k8s_version" {
   type        = string
   description = "Kubernetes version to deploy"


### PR DESCRIPTION
All this does is add the ability to configure these options, the defaults used match the aws resource defaults as [shown here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_cluster#endpoint_private_access), but it's required for soc2 and vanta. I've already actually made this change on workhands, backporting it now.