### PR TITLE
Add custom group option to aws auth config map builder

### DIFF
--- a/aws/platform/README.md
+++ b/aws/platform/README.md
@@ -172,6 +172,7 @@ You can then use it to manually edit the aws-auth ConfigMap:
 | <a name="input_certificate_issuer"></a> [certificate\_issuer](#input\_certificate\_issuer) | YAML spec for certificate issuer; defaults to self-signed | `string` | `null` | no |
 | <a name="input_cluster_autoscaler_values"></a> [cluster\_autoscaler\_values](#input\_cluster\_autoscaler\_values) | Overrides to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the EKS cluster | `string` | n/a | yes |
+| <a name="input_custom_groups"></a> [custom\_groups](#input\_custom\_groups) | List of custom RBAC groups to be assigned to an IAM role for custom cluster privileges, | `map(list(string))` | `{}` | no |
 | <a name="input_custom_roles"></a> [custom\_roles](#input\_custom\_roles) | Additional IAM roles which have custom cluster privileges | `map(string)` | `{}` | no |
 | <a name="input_domain_names"></a> [domain\_names](#input\_domain\_names) | Domains which are allowed in this cluster | `list(string)` | `[]` | no |
 | <a name="input_external_dns_enabled"></a> [external\_dns\_enabled](#input\_external\_dns\_enabled) | Set to true to enable External DNS | `bool` | `false` | no |

--- a/aws/platform/main.tf
+++ b/aws/platform/main.tf
@@ -102,6 +102,7 @@ module "auth_config_map" {
   admin_roles       = var.admin_roles
   cluster_full_name = module.cluster_name.full
   custom_roles      = var.custom_roles
+  custom_groups     = var.custom_groups
   node_roles        = concat(local.node_roles, var.node_roles)
 }
 

--- a/aws/platform/modules/auth-config-map/README.md
+++ b/aws/platform/modules/auth-config-map/README.md
@@ -33,6 +33,7 @@
 |------|-------------|------|---------|:--------:|
 | <a name="input_admin_roles"></a> [admin\_roles](#input\_admin\_roles) | Role ARNs which have admin privileges within the cluster | `list(string)` | n/a | yes |
 | <a name="input_cluster_full_name"></a> [cluster\_full\_name](#input\_cluster\_full\_name) | Full name of the EKS cluster | `string` | n/a | yes |
+| <a name="input_custom_groups"></a> [custom\_groups](#input\_custom\_groups) | RBAC groups to be assigned to an IAM role for custom privileges within the cluster | `map(list(string))` | `{}` | no |
 | <a name="input_custom_roles"></a> [custom\_roles](#input\_custom\_roles) | Role ARNs which have custom privileges within the cluster | `map(string)` | `{}` | no |
 | <a name="input_node_roles"></a> [node\_roles](#input\_node\_roles) | Roles for EKS node groups in this cluster | `list(string)` | n/a | yes |
 

--- a/aws/platform/modules/auth-config-map/main.tf
+++ b/aws/platform/modules/auth-config-map/main.tf
@@ -100,6 +100,14 @@ locals {
       }
     ],
     [
+      for role, groups in var.custom_groups :
+      {
+        groups   = groups
+        rolearn  = role
+        username = "user:{{SessionName}}"
+      }
+    ],
+    [
       for role in var.node_roles :
       {
         username = "system:node:{{EC2PrivateDNSName}}"

--- a/aws/platform/modules/auth-config-map/variables.tf
+++ b/aws/platform/modules/auth-config-map/variables.tf
@@ -19,6 +19,12 @@ variable "custom_roles" {
   description = "Role ARNs which have custom privileges within the cluster"
 }
 
+variable "custom_groups" {
+  type        = map(list(string))
+  default     = {}
+  description = "RBAC groups to be assigned to an IAM role for custom privileges within the cluster"
+}
+
 variable "node_roles" {
   type        = list(string)
   description = "Roles for EKS node groups in this cluster"

--- a/aws/platform/variables.tf
+++ b/aws/platform/variables.tf
@@ -62,6 +62,12 @@ variable "cluster_name" {
   description = "Name of the EKS cluster"
 }
 
+variable "custom_groups" {
+  type        = map(list(string))
+  description = "List of custom RBAC groups to be assigned to an IAM role for custom cluster privileges,"
+  default     = {}
+}
+
 variable "custom_roles" {
   type        = map(string)
   description = "Additional IAM roles which have custom cluster privileges"


### PR DESCRIPTION
At the moment, the custom_roles input is not suitable when we have to reuse a role for multiple groups.

This update will enable us to pass in the groups to be associated with a role using the custom_groups input instead.

the role will be the key, and the list of groups will be be value.