### PR TITLE
Update workload platform v5

### DIFF
--- a/aws/platform/main.tf
+++ b/aws/platform/main.tf
@@ -77,6 +77,7 @@ module "aws_load_balancer_controller" {
   k8s_namespace     = var.k8s_namespace
   oidc_issuer       = data.aws_ssm_parameter.oidc_issuer.value
   vpc_cidr_block    = module.network.vpc.cidr_block
+  vpc_id            = module.network.vpc.id
 
   depends_on = [module.common_platform]
 }

--- a/aws/platform/modules/load-balancer-controller/README.md
+++ b/aws/platform/modules/load-balancer-controller/README.md
@@ -36,6 +36,7 @@ target group bound to the Istio ingress gateway service.
 | [helm_release.ingress_config](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.this](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [aws_lb_target_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb_target_group) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
@@ -53,4 +54,5 @@ target group bound to the Istio ingress gateway service.
 | <a name="input_oidc_issuer"></a> [oidc\_issuer](#input\_oidc\_issuer) | OIDC issuer of the Kubernetes cluster | `string` | n/a | yes |
 | <a name="input_target_group_name"></a> [target\_group\_name](#input\_target\_group\_name) | Override the name of the target group for this cluster | `string` | `null` | no |
 | <a name="input_vpc_cidr_block"></a> [vpc\_cidr\_block](#input\_vpc\_cidr\_block) | CIDR block for the AWS VPC in which the load balancer runs | `string` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID for the Kubernetes cluster. | `string` | n/a | yes |
 <!-- END_TF_DOCS -->

--- a/aws/platform/modules/load-balancer-controller/main.tf
+++ b/aws/platform/modules/load-balancer-controller/main.tf
@@ -76,6 +76,8 @@ resource "aws_iam_role_policy_attachment" "this" {
   policy_arn = aws_iam_policy.this.arn
 }
 
+data "aws_region" "current" {}
+
 locals {
   chart_defaults = jsondecode(file("${path.module}/chart.json"))
 
@@ -90,6 +92,8 @@ locals {
           "eks.amazonaws.com/role-arn" = module.service_account_role.arn
         }
       }
+      region = data.aws_region.current.name
+      vpcId  = var.vpc_id
     })
   ]
 }

--- a/aws/platform/modules/load-balancer-controller/variables.tf
+++ b/aws/platform/modules/load-balancer-controller/variables.tf
@@ -66,3 +66,8 @@ variable "vpc_cidr_block" {
   type        = string
   description = "CIDR block for the AWS VPC in which the load balancer runs"
 }
+
+variable "vpc_id" {
+  type        = string
+  description = "The VPC ID for the Kubernetes cluster."
+}

--- a/charts.json
+++ b/charts.json
@@ -7,7 +7,7 @@
   "cert-manager": {
     "chart": "cert-manager",
     "repository": "https://charts.jetstack.io",
-    "version": "v1.10.1"
+    "version": "v1.12.13"
   },
   "cluster-autoscaler": {
     "chart": "cluster-autoscaler",
@@ -27,17 +27,17 @@
   "istio-base": {
     "chart": "base",
     "repository": "https://istio-release.storage.googleapis.com/charts",
-    "version": "1.22.3"
+    "version": "1.23.0"
   },
   "istiod": {
     "chart": "istiod",
     "repository": "https://istio-release.storage.googleapis.com/charts",
-    "version": "1.22.3"
+    "version": "1.23.0"
   },
   "istio-ingress": {
     "chart": "gateway",
     "repository": "https://istio-release.storage.googleapis.com/charts",
-    "version": "1.22.3"
+    "version": "1.23.0"
   },
   "load-balancer-controller": {
     "chart": "aws-load-balancer-controller",

--- a/charts.json
+++ b/charts.json
@@ -27,17 +27,17 @@
   "istio-base": {
     "chart": "base",
     "repository": "https://istio-release.storage.googleapis.com/charts",
-    "version": "1.16.1"
+    "version": "1.22.3"
   },
   "istiod": {
     "chart": "istiod",
     "repository": "https://istio-release.storage.googleapis.com/charts",
-    "version": "1.16.1"
+    "version": "1.22.3"
   },
   "istio-ingress": {
     "chart": "gateway",
     "repository": "https://istio-release.storage.googleapis.com/charts",
-    "version": "1.16.1"
+    "version": "1.22.3"
   },
   "load-balancer-controller": {
     "chart": "aws-load-balancer-controller",

--- a/platform/modules/cert-manager/chart.json
+++ b/platform/modules/cert-manager/chart.json
@@ -1,5 +1,5 @@
 {
   "chart": "cert-manager",
   "repository": "https://charts.jetstack.io",
-  "version": "v1.10.1"
+  "version": "v1.12.13"
 }

--- a/platform/modules/istio-base/chart.json
+++ b/platform/modules/istio-base/chart.json
@@ -1,5 +1,5 @@
 {
   "chart": "base",
   "repository": "https://istio-release.storage.googleapis.com/charts",
-  "version": "1.22.3"
+  "version": "1.23.0"
 }

--- a/platform/modules/istio-base/chart.json
+++ b/platform/modules/istio-base/chart.json
@@ -1,5 +1,5 @@
 {
   "chart": "base",
   "repository": "https://istio-release.storage.googleapis.com/charts",
-  "version": "1.16.1"
+  "version": "1.22.3"
 }

--- a/platform/modules/istio-ingress/chart.json
+++ b/platform/modules/istio-ingress/chart.json
@@ -1,5 +1,5 @@
 {
   "chart": "gateway",
   "repository": "https://istio-release.storage.googleapis.com/charts",
-  "version": "1.22.3"
+  "version": "1.23.0"
 }

--- a/platform/modules/istio-ingress/chart.json
+++ b/platform/modules/istio-ingress/chart.json
@@ -1,5 +1,5 @@
 {
   "chart": "gateway",
   "repository": "https://istio-release.storage.googleapis.com/charts",
-  "version": "1.16.1"
+  "version": "1.22.3"
 }

--- a/platform/modules/istiod/chart.json
+++ b/platform/modules/istiod/chart.json
@@ -1,5 +1,5 @@
 {
   "chart": "istiod",
   "repository": "https://istio-release.storage.googleapis.com/charts",
-  "version": "1.22.3"
+  "version": "1.23.0"
 }

--- a/platform/modules/istiod/chart.json
+++ b/platform/modules/istiod/chart.json
@@ -1,5 +1,5 @@
 {
   "chart": "istiod",
   "repository": "https://istio-release.storage.googleapis.com/charts",
-  "version": "1.16.1"
+  "version": "1.22.3"
 }


### PR DESCRIPTION
Update helm charts work kubernetes workload platform
Fix breaking change with AWS load balancer controller. The load balancer controller is unable to fetch vpc details from nodes running with EKS > 1.30. This update will pass the vpc details directly to the helm chart to fix the breaking change.