### PR TITLE
Allow requiring IMDSv2 on Node Group instances

### DIFF
--- a/aws/cluster/README.md
+++ b/aws/cluster/README.md
@@ -103,7 +103,7 @@ module "cluster" {
 | <a name="input_log_retention_in_days"></a> [log\_retention\_in\_days](#input\_log\_retention\_in\_days) | How many days until control plane logs are purged | `number` | `7` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name for this EKS cluster | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Prefix to be applied to created resources | `list(string)` | `[]` | no |
-| <a name="input_node_groups"></a> [node\_groups](#input\_node\_groups) | Node groups to create in this cluster | <pre>map(object({<br>    capacity_type   = optional(string, "ON_DEMAND")<br>    instance_types  = list(string),<br>    max_size        = number<br>    max_unavailable = optional(number, 3)<br>    min_size        = number<br>  }))</pre> | n/a | yes |
+| <a name="input_node_groups"></a> [node\_groups](#input\_node\_groups) | Node groups to create in this cluster | <pre>map(object({<br>    capacity_type   = optional(string, "ON_DEMAND")<br>    instance_types  = list(string),<br>    enforce_imdsv2  = optional(bool, false)<br>    max_size        = number<br>    max_unavailable = optional(number, 3)<br>    min_size        = number<br>  }))</pre> | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to all created resources | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/aws/cluster/main.tf
+++ b/aws/cluster/main.tf
@@ -44,6 +44,7 @@ module "node_groups" {
   capacity_type   = each.value.capacity_type
   cluster         = module.eks_cluster.instance
   instance_types  = each.value.instance_types
+  enforce_imdsv2  = each.value.enforce_imdsv2
   labels          = var.labels
   max_size        = each.value.max_size
   max_unavailable = each.value.max_unavailable

--- a/aws/cluster/modules/eks-node-group/README.md
+++ b/aws/cluster/modules/eks-node-group/README.md
@@ -17,6 +17,7 @@
 | Name | Type |
 |------|------|
 | [aws_eks_node_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group) | resource |
+| [aws_launch_template.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
 
 ## Inputs
 
@@ -24,6 +25,7 @@
 |------|-------------|------|---------|:--------:|
 | <a name="input_capacity_type"></a> [capacity\_type](#input\_capacity\_type) | Allow values: ON\_DEMAND (default), SPOT | `string` | `"ON_DEMAND"` | no |
 | <a name="input_cluster"></a> [cluster](#input\_cluster) | Cluster which this node group should join | `object({ name = string })` | n/a | yes |
+| <a name="input_enforce_imdsv2"></a> [enforce\_imdsv2](#input\_enforce\_imdsv2) | Whether to enforce IMDSv2 on the launch template | `bool` | `false` | no |
 | <a name="input_instance_types"></a> [instance\_types](#input\_instance\_types) | EC2 instance types allowed in this node group | `list(string)` | <pre>[<br>  "t3.medium"<br>]</pre> | no |
 | <a name="input_label_node_role"></a> [label\_node\_role](#input\_label\_node\_role) | Role to struct kubernetes scheduler to use for this node group | `string` | `"general"` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to be applied to created resources | `map(string)` | `{}` | no |

--- a/aws/cluster/modules/eks-node-group/variables.tf
+++ b/aws/cluster/modules/eks-node-group/variables.tf
@@ -69,3 +69,9 @@ variable "max_unavailable" {
   description = "Maximum number of nodes that can be unavailable during a rolling update"
   default     = 1
 }
+
+variable "enforce_imdsv2" {
+  type        = bool
+  description = "Whether to enforce IMDSv2 on the launch template"
+  default     = false
+}

--- a/aws/cluster/variables.tf
+++ b/aws/cluster/variables.tf
@@ -44,6 +44,7 @@ variable "node_groups" {
   type = map(object({
     capacity_type   = optional(string, "ON_DEMAND")
     instance_types  = list(string),
+    enforce_imdsv2  = optional(bool, false)
     max_size        = number
     max_unavailable = optional(number, 3)
     min_size        = number


### PR DESCRIPTION
When creating a new Node Group, one can specify if they need EC2
instances to enforce IMDSv2.

This is a SOC2 compliance requirement.