### PR TITLE
Grant cluster wide crd access to deploy roles

### DIFF
--- a/aws/deploy-role-bindings/README.md
+++ b/aws/deploy-role-bindings/README.md
@@ -60,8 +60,10 @@ module "workload_platform" {
 
 | Name | Type |
 |------|------|
+| [kubernetes_cluster_role.cluster_crd](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role) | resource |
+| [kubernetes_cluster_role_binding.cluster](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_binding) | resource |
+| [kubernetes_cluster_role_binding.cluster_crd](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_binding) | resource |
 | [kubernetes_role.deploy_crd](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role) | resource |
-| [kubernetes_role_binding.cluster](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role_binding) | resource |
 | [kubernetes_role_binding.crd](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role_binding) | resource |
 
 ## Inputs

--- a/aws/deploy-role-bindings/main.tf
+++ b/aws/deploy-role-bindings/main.tf
@@ -2,7 +2,7 @@ resource "kubernetes_cluster_role_binding" "cluster" {
   for_each = toset(var.cluster_roles)
 
   metadata {
-    name      = var.name
+    name = var.name
   }
 
   role_ref {
@@ -32,7 +32,7 @@ resource "kubernetes_cluster_role" "cluster_crd" {
 
 resource "kubernetes_cluster_role_binding" "cluster_crd" {
   metadata {
-    name      = "${var.name}-cluster-crd"
+    name = "${var.name}-cluster-crd"
   }
 
   role_ref {
@@ -47,7 +47,7 @@ resource "kubernetes_cluster_role_binding" "cluster_crd" {
     api_group = "rbac.authorization.k8s.io"
   }
 
-  depends_on = [ kubernetes_cluster_role.cluster_crd ]
+  depends_on = [kubernetes_cluster_role.cluster_crd]
 }
 
 resource "kubernetes_role_binding" "crd" {

--- a/aws/deploy-role-bindings/main.tf
+++ b/aws/deploy-role-bindings/main.tf
@@ -1,9 +1,8 @@
-resource "kubernetes_role_binding" "cluster" {
+resource "kubernetes_cluster_role_binding" "cluster" {
   for_each = toset(var.cluster_roles)
 
   metadata {
     name      = var.name
-    namespace = var.namespace
   }
 
   role_ref {
@@ -17,6 +16,38 @@ resource "kubernetes_role_binding" "cluster" {
     name      = var.group
     api_group = "rbac.authorization.k8s.io"
   }
+}
+
+resource "kubernetes_cluster_role" "cluster_crd" {
+  metadata {
+    name = "${var.name}-cluster-crd"
+  }
+
+  rule {
+    api_groups = ["apiextensions.k8s.io"]
+    resources  = ["customresourcedefinitions"]
+    verbs      = ["get", "list"]
+  }
+}
+
+resource "kubernetes_cluster_role_binding" "cluster_crd" {
+  metadata {
+    name      = "${var.name}-cluster-crd"
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "${var.name}-cluster-crd"
+  }
+
+  subject {
+    kind      = "Group"
+    name      = var.group
+    api_group = "rbac.authorization.k8s.io"
+  }
+
+  depends_on = [ kubernetes_cluster_role.cluster_crd ]
 }
 
 resource "kubernetes_role_binding" "crd" {


### PR DESCRIPTION
During deploys, we have errors while accessing customresourcedefinitions. This change will grant cluster wide access for customresourcedefinitions to the deploy roles.