### PR TITLE
Allow dependent modules to specify Grafana version

### DIFF
--- a/aws/grafana-workspace/README.md
+++ b/aws/grafana-workspace/README.md
@@ -72,9 +72,10 @@ module "grafana_workspace" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_admin_groups"></a> [admin\_groups](#input\_admin\_groups) | IAM Identity Center groups with administrator access to Grafana | `list(string)` | `[]` | no |
-| <a name="input_authentication_providers"></a> [authentication\_providers](#input\_authentication\_providers) | Providers used to sign in to Grafana | `list(string)` | <pre>[<br>  "AWS_SSO"<br>]</pre> | no |
+| <a name="input_authentication_providers"></a> [authentication\_providers](#input\_authentication\_providers) | Providers used to sign in to Grafana | `list(string)` | <pre>[<br/>  "AWS_SSO"<br/>]</pre> | no |
 | <a name="input_editor_groups"></a> [editor\_groups](#input\_editor\_groups) | IAM Identity Center groups with edit access to Grafana | `list(string)` | `[]` | no |
 | <a name="input_grafana_api_key_name"></a> [grafana\_api\_key\_name](#input\_grafana\_api\_key\_name) | Name for the Grafana API key used by Terraform | `string` | `"terraform"` | no |
+| <a name="input_grafana_version"></a> [grafana\_version](#input\_grafana\_version) | Version of AWS Managed Grafana to use (e.g., '11.3.0') | `string` | `null` | no |
 | <a name="input_iam_role_name"></a> [iam\_role\_name](#input\_iam\_role\_name) | Override the name of the service role for Grafana | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of this Grafana workspace | `string` | `"Grafana"` | no |
 | <a name="input_viewer_groups"></a> [viewer\_groups](#input\_viewer\_groups) | IAM Identity Center groups with view access to Grafana | `list(string)` | `[]` | no |

--- a/aws/grafana-workspace/main.tf
+++ b/aws/grafana-workspace/main.tf
@@ -6,6 +6,7 @@ resource "aws_grafana_workspace" "this" {
   notification_destinations = ["SNS"]
   permission_type           = "CUSTOMER_MANAGED"
   role_arn                  = aws_iam_role.grafana.arn
+  grafana_version           = var.grafana_version
 
   configuration = jsonencode({
     unifiedAlerting = { enabled = true }

--- a/aws/grafana-workspace/variables.tf
+++ b/aws/grafana-workspace/variables.tf
@@ -45,3 +45,9 @@ variable "viewer_groups" {
   type        = list(string)
   default     = []
 }
+
+variable "grafana_version" {
+  description = "Specifies the version of Grafana to support in the workspace."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
This PR provides dependent modules with the ability to [specify a Grafana version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/grafana_workspace#grafana_version-1) to support in the workspace.

We (Three Ships/Home Solutions) would like to upgrade our Grafana version from `9.4.7` to the latest AWS-support Grafana version (`10.4` according to the docs linked to above). Ideally, we'd like to upgrade to the latest version, but the resource does not appear to support that.

With this change, I **believe** we would just need to modify our module like so:

```
module "grafana_workspace" {
  providers = ...
  source    = "github.com/thoughtbot/flightdeck//aws/grafana-workspace?ref=10bd932" # change to point to this commit

  name = ...
  grafana_version = "10.4" # specify the latest supported version

  admin_groups = [
    ...
  ]

  editor_groups = [
    ...
  ]

  workload_account_ids = [
    ...
  ]
}
```

Please advise if this patch will achieve the outcome we are looking for. I'm a bit of a Terraform noob, so apologies if this patch is lacking; happy to make any necessary changes. Thanks!